### PR TITLE
Reintroduce bounded/unbounded assumptions

### DIFF
--- a/sympy/core/add.py
+++ b/sympy/core/add.py
@@ -446,6 +446,9 @@ class Add(Expr, AssocOp):
     def _eval_is_finite(self):
         return _fuzzy_group((a.is_finite for a in self.args), quick_exit=True)
 
+    def _eval_is_bounded(self):
+        return _fuzzy_group((a.is_bounded for a in self.args), quick_exit=True)
+
     def _eval_is_hermitian(self):
         return _fuzzy_group((a.is_hermitian for a in self.args), quick_exit=True)
 

--- a/sympy/core/assumptions.py
+++ b/sympy/core/assumptions.py
@@ -90,6 +90,11 @@ Here follows a list of possible assumption names:
         object absolute value is bounded (is value is
         arbitrarily large).  See [7]_, [8]_, [9]_.
 
+    bounded
+    unbounded
+        object is a bounded (unbounded) set [14]_
+        or is finite (infinite).
+
     negative
     nonnegative
         object can have only negative (only
@@ -149,7 +154,7 @@ References
 .. [11] http://en.wikipedia.org/wiki/Algebraic_number
 .. [12] http://en.wikipedia.org/wiki/Real_number
 .. [13] http://en.wikipedia.org/wiki/Extended_real_number_line
-
+.. [14] http://en.wikipedia.org/wiki/Bounded_set
 """
 
 from random import shuffle
@@ -195,6 +200,10 @@ _assume_rules = FactRules([
     'nonzero        ==  ~zero',
 
     'polar          -> commutative',
+
+    'unbounded      -> ~bounded',
+    'finite         -> bounded',
+    'infinite       -> unbounded',
 ])
 
 _assume_defined = frozenset(_assume_rules.defined_facts.copy())

--- a/sympy/core/mul.py
+++ b/sympy/core/mul.py
@@ -964,6 +964,9 @@ class Mul(Expr, AssocOp):
     def _eval_is_finite(self):
         return _fuzzy_group(a.is_finite for a in self.args)
 
+    def _eval_is_bounded(self):
+        return _fuzzy_group(a.is_bounded for a in self.args)
+
     def _eval_is_complex(self):
         return _fuzzy_group((a.is_complex for a in self.args), quick_exit=True)
 

--- a/sympy/core/power.py
+++ b/sympy/core/power.py
@@ -481,6 +481,11 @@ class Pow(Expr):
             elif self.base is S.NegativeOne:
                 return True
 
+    def _eval_is_bounded(self):
+        if self.exp.is_finite and self.exp.is_positive:
+            if self.base.is_bounded:
+                return True
+
     def _eval_is_finite(self):
         if self.exp.is_negative:
             if self.base.is_zero:

--- a/sympy/functions/elementary/trigonometric.py
+++ b/sympy/functions/elementary/trigonometric.py
@@ -399,6 +399,9 @@ class sin(TrigonometricFunction):
     def _eval_is_real(self):
         return self.args[0].is_real
 
+    def _eval_is_bounded(self):
+        return True
+
 
 class cos(TrigonometricFunction):
     """
@@ -773,6 +776,9 @@ class cos(TrigonometricFunction):
 
     def _eval_is_complex(self):
         return self.args[0].is_complex
+
+    def _eval_is_bounded(self):
+        return True
 
 
 class tan(TrigonometricFunction):

--- a/sympy/printing/tree.py
+++ b/sympy/printing/tree.py
@@ -81,6 +81,7 @@ def print_tree(node):
     commutative: True
     +-Symbol: y
     | algebraic: True
+    | bounded: True
     | commutative: True
     | complex: True
     | even: True
@@ -95,8 +96,10 @@ def print_tree(node):
     | rational: True
     | real: True
     | transcendental: False
+    | unbounded: False
     +-Symbol: x
       algebraic: True
+      bounded: True
       commutative: True
       complex: True
       even: False
@@ -113,6 +116,7 @@ def print_tree(node):
       rational: True
       real: True
       transcendental: False
+      unbounded: False
       zero: False
 
     See also: tree()

--- a/sympy/series/limits.py
+++ b/sympy/series/limits.py
@@ -43,8 +43,7 @@ def heuristics(e, z, z0, dir):
         r = []
         for a in e.args:
             l = limit(a, z, z0, dir)
-            if l.has(S.Infinity) and (l.func not in (sin, cos) and
-                                      l.is_finite is None):
+            if l.has(S.Infinity) and l.is_bounded is None:
                 return
             elif isinstance(l, Limit):
                 return


### PR DESCRIPTION
For sets (or Symbol's, that represent sets) - these mean
bounded/unbounded sets.  But for Symbol's, that represent
numbers - usual finite/infinite assumption.

We don't support yet set algebra (i.e. expressions with Interval's), but
this seems to be a good feature in future.  But already right now we should
keep in mind that things like sin(oo) are not numbers and finite or
extended_real assumptions - not valid for them.

The bounded/unbounded pair of assumptions - could be helpful in such
cases as a generalization of the finite/infinite pair for sets.  Please
note, that right now it's used only in the heuristics() function
of the limit module.

Relevant refs:
https://github.com/sympy/sympy/issues/7943
https://github.com/sympy/sympy/pull/7891
https://github.com/sympy/sympy/issues/5393
