### PR TITLE
Cartesian product of iterables using Cantor pairing

### DIFF
--- a/sympy/ntheory/residue_ntheory.py
+++ b/sympy/ntheory/residue_ntheory.py
@@ -4,6 +4,7 @@ from sympy.core.singleton import S
 from sympy.core.numbers import igcd, igcdex
 from sympy.core.compatibility import as_int
 from sympy.core.function import Function
+from sympy.utilities.iterables import cantor_product
 from .primetest import isprime
 from .factor_ import factorint, trailing, totient
 
@@ -252,36 +253,6 @@ def sqrt_mod(a, p, all_roots=False):
         return
 
 
-def _product(*iters):
-    """Cartesian product generator.
-
-    Notes
-    =====
-
-    Unlike itertools.product, it works also with iterables which do not fit
-    in memory.  See http://bugs.python.org/issue10109.
-    """
-    import itertools
-    inf_iters = tuple(itertools.cycle(enumerate(it)) for it in iters)
-    num_iters = len(inf_iters)
-    cur_val = [None]*num_iters
-
-    first_v = True
-    while True:
-        i, p = 0, num_iters
-        while p and not i:
-            p -= 1
-            i, cur_val[p] = next(inf_iters[p])
-
-        if not p and not i:
-            if first_v:
-                first_v = False
-            else:
-                break
-
-        yield cur_val
-
-
 def sqrt_mod_iter(a, p, domain=int):
     """Iterate over solutions to ``x**2 = a mod p``.
 
@@ -332,11 +303,11 @@ def sqrt_mod_iter(a, p, domain=int):
             pv.append(px**ex)
         mm, e, s = gf_crt1(pv, ZZ)
         if domain is ZZ:
-            for vx in _product(*v):
+            for vx in cantor_product(*v):
                 r = gf_crt2(vx, pv, mm, e, s, ZZ)
                 yield r
         else:
-            for vx in _product(*v):
+            for vx in cantor_product(*v):
                 r = gf_crt2(vx, pv, mm, e, s, ZZ)
                 yield domain(r)
 

--- a/sympy/sets/fancysets.py
+++ b/sympy/sets/fancysets.py
@@ -4,7 +4,8 @@ from sympy.sets.sets import Set, Interval, Intersection, EmptySet, FiniteSet
 from sympy.core.singleton import Singleton, S
 from sympy.core.sympify import _sympify
 from sympy.core.function import Lambda
-from sympy.core.numbers import Integer
+from sympy.core.numbers import Integer, Rational
+from sympy.utilities.iterables import cantor_product
 
 
 class Naturals(Set, metaclass=Singleton):
@@ -195,6 +196,14 @@ class Rationals(Set, metaclass=Singleton):
     @property
     def _boundary(self):
         return self
+
+    def __iter__(self):
+        seen = []
+        for n, d in cantor_product(S.Integers, S.Naturals):
+            r = Rational(n, d)
+            if r not in seen:
+                seen.append(r)
+                yield r
 
 
 class Reals(Interval, metaclass=Singleton):

--- a/sympy/sets/sets.py
+++ b/sympy/sets/sets.py
@@ -622,8 +622,9 @@ class ProductSet(Set):
         return all(set.is_iterable for set in self.sets)
 
     def __iter__(self):
+        from sympy.utilities.iterables import cantor_product
         if self.is_iterable:
-            return itertools.product(*self.sets)
+            return cantor_product(*self.sets)
         else:
             raise TypeError("Not all constituent sets are iterable")
 

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -6,7 +6,7 @@ from sympy.sets.fancysets import ImageSet, Range
 from sympy.sets.contains import Contains
 from sympy.sets.sets import FiniteSet, Interval, imageset, EmptySet
 from sympy import (S, Symbol, Lambda, symbols, cos, sin, pi, oo, Basic,
-                   Rational, sqrt, tan, log, Abs, exp, I)
+                   Integer, Rational, sqrt, tan, log, Abs, exp, I)
 
 from sympy.abc import x, n, m, t
 
@@ -68,6 +68,13 @@ def test_rationals():
     assert Q.sup == oo
 
     assert Q.boundary == Q
+
+    assert (list(itertools.islice(S.Rationals, 17)) ==
+            [Integer(0), Integer(1), Rational(1, 2), Rational(1, 3),
+             Integer(-1), Rational(-1, 2), Rational(-1, 3), Rational(1, 4),
+             Rational(-1, 4), Integer(2), Rational(2, 3), Rational(1, 5),
+             Rational(-1, 5), Rational(2, 5), Integer(-2),
+             Rational(-2, 3), Rational(-2, 5)])
 
 
 def test_ImageSet():

--- a/sympy/sets/tests/test_fancysets.py
+++ b/sympy/sets/tests/test_fancysets.py
@@ -279,3 +279,9 @@ def test_ImageSet_simplification():
     assert (imageset(Lambda(n, sin(n)),
                      imageset(Lambda(m, tan(m)), S.Integers)) ==
             imageset(Lambda(m, sin(tan(m))), S.Integers))
+
+
+def test_issue_10497():
+    # __iter__ for infinite product set
+    assert (list(itertools.islice(iter(S.Integers**2), 7)) ==
+            [(0, 0), (0, 1), (1, 0), (1, 1), (0, -1), (1, -1), (-1, 0)])

--- a/sympy/utilities/iterables.py
+++ b/sympy/utilities/iterables.py
@@ -2092,3 +2092,39 @@ def kbins(l, k, ordered=None):
     else:
         raise ValueError(
             'ordered must be one of 00, 01, 10 or 11, not %s' % ordered)
+
+
+def cantor_product(*args):
+    """ Breadth-first (diagonal) cartesian product of iterables.
+
+    Each iterable is advanced in turn in a round-robin fashion. As usual with
+    breadth-first, this comes at the cost of memory consumption.
+
+    >>> from itertools import islice, count
+    >>> list(islice(cantor_product(count(), count()), 9))
+    [(0, 0), (0, 1), (1, 0), (1, 1), (0, 2), (1, 2), (2, 0), (2, 1), (2, 2)]
+    """
+    args = list(map(iter, args))
+
+    try:
+        argslist = [[next(a)] for a in args]
+    except StopIteration:
+        return
+    else:
+        yield tuple(a[0] for a in argslist)
+
+    nargs = len(args)
+    exhausted = [False]*nargs
+    n = nargs
+
+    while not all(exhausted):
+        n = (n - 1) % nargs
+        if not exhausted[n]:
+            try:
+                argslist[n].append(next(args[n]))
+            except StopIteration:
+                exhausted[n] = True
+            else:
+                for result in product(*(argslist[:n] + [argslist[n][-1:]] +
+                                        argslist[n + 1:])):
+                    yield result

--- a/sympy/utilities/tests/test_iterables.py
+++ b/sympy/utilities/tests/test_iterables.py
@@ -1,3 +1,5 @@
+import itertools
+import random
 from textwrap import dedent
 
 import pytest
@@ -14,7 +16,7 @@ from sympy.utilities.iterables import (
     multiset_permutations, necklaces, numbered_symbols, ordered, partitions,
     permutations, postfixes, postorder_traversal, prefixes, reshape,
     rotate_left, rotate_right, runs, sift, subsets, take, topological_sort,
-    unflatten, uniq, variations)
+    unflatten, uniq, variations, cantor_product)
 from sympy.utilities.enumerative import (factoring_visitor,
                                          multiset_partitions_taocp)
 from sympy.core.singleton import S
@@ -700,3 +702,30 @@ def test__partition():
         ['b', 'e'], ['a', 'c'], ['d']]
     output = (3, [1, 0, 1, 2, 0])
     assert _partition('abcde', *output) == [['b', 'e'], ['a', 'c'], ['d']]
+
+
+def test_cantor_product():
+    assert list(cantor_product([], [1, 2])) == []
+    assert list(cantor_product([], itertools.count(1))) == []
+
+    assert (list(cantor_product([1, 2, 3], [3, 4])) ==
+            [(1, 3), (1, 4), (2, 3), (2, 4), (3, 3), (3, 4)])
+
+    assert (sorted(cantor_product([1, 2, 3], [3, 4])) ==
+            sorted(itertools.product([1, 2, 3], [3, 4])))
+
+    l1 = [random.randint(0, 100) for a in range(10)]
+    l2 = [random.randint(0, 100) for a in range(10)]
+    assert (sorted(list(cantor_product(l1, l2))) ==
+            sorted(list(itertools.product(l1, l2))))
+
+    assert (list(itertools.islice(cantor_product([1, 2],
+                                                 itertools.count(3)), 10)) ==
+            [(1, 3), (1, 4), (2, 3), (2, 4), (1, 5), (2, 5), (1, 6), (2, 6), (1, 7), (2, 7)])
+    assert (list(itertools.islice(cantor_product([1, 2, 3],
+                                                 itertools.count(4)), 10)) ==
+            [(1, 4), (1, 5), (2, 4), (2, 5), (1, 6), (2, 6), (3, 4), (3, 5), (3, 6), (1, 7)])
+
+    assert (list(itertools.islice(cantor_product(itertools.count(1),
+                                                 itertools.count(1)), 7)) ==
+            [(1, 1), (1, 2), (2, 1), (2, 2), (1, 3), (2, 3), (3, 1)])


### PR DESCRIPTION
Used in ProductSet.\__iter__ to fix sympy/sympy#10497

- [x] more tests
- [x] simplify?
- [x] use for Rationals set
- [x] use this in ntheory?
