### PR TITLE
dsolve: expm/jordan solver

### DIFF
--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6321,69 +6321,7 @@ def sysode_linear_order1_jordan(match_):
     A = M.inv()*L
     T, JJ = A.jordan_cells()
 
-    if all(a.is_extended_real for a in A):
-        # If matrix A is real: special treatment for conj pairs
-        def imag(q):
-            return (q - q.conjugate())/(2*I)
-
-        def real(q):
-            return (q + q.conjugate())/2
-
-        def extract_eigenvector_blocks(JJ, evs):
-            TT = []
-            c = 0
-            for J in JJ:
-                mult = J.rows
-                TT.append([evs.col(i) for i in range(c, c + mult)])
-                c = c + mult
-            assert len(TT) == len(JJ)
-            assert c == evs.cols
-            return TT
-
-        def make_exp_real_jordan_block(m, a, b, t, T):
-            R = Matrix([[cos(b*t), sin(b*t)], [-sin(b*t), cos(b*t)]])
-            expm = Matrix(2*m, 2*m, lambda r, c: 0)
-            for i in range(m):
-                for j in range(i, m):
-                    r = j - i
-                    expm[2*i:2*i+2, 2*j:2*j+2] = t**r/factorial(r)*R
-            expm = exp(a*t)*expm
-            T2 = []
-            for ev in T:
-                T2.extend([real(ev), imag(ev)])
-            return (expm, T2)
-
-        TT = extract_eigenvector_blocks(JJ, T)
-
-        # list of eigenvalues
-        ll = [J[0, 0] for J in JJ]
-
-        expm_list = []
-        ev_lol = []
-        for i in range(len(JJ)):
-            J = JJ[i]
-            evs = TT[i]
-            l = J[0, 0]
-            if l.is_complex and l.is_extended_real is False:
-                a, b = real(l), imag(l)
-                if b.is_positive:
-                    m = J.rows
-                    myexpm, myevs = make_exp_real_jordan_block(m, a, b, t, evs)
-                    expm_list.append(myexpm)
-                    ev_lol.append(myevs)
-            else:
-                expm_list.append((J*t).exp())
-                ev_lol.append(evs)
-        expm = Matrix(BlockDiagMatrix(*expm_list))
-
-        # rebuild matrix with eigenvector columns
-        T = Matrix(n, 0, [])
-        for evs in ev_lol:
-            for ev in evs:
-                T = T.row_join(ev)
-    else:
-        expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
-
+    expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
     q = T*expm*T.inv()
     Cvec = Matrix(get_numbered_constants(eq, num=n))
     q = q*Cvec

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6341,9 +6341,10 @@ def sysode_linear_order1_jordan(match_):
 
     A = M.inv()*L
     T, JJ = A.jordan_cells()
+    T, Tinv = map(simplify, [T, T.inv()])
 
     expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
-    q = T*expm*T.inv()
+    q = T*expm*Tinv
     Cvec = Matrix(get_numbered_constants(eq, num=n))
     q = q*Cvec
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -1441,12 +1441,12 @@ def classify_sysode(eq, funcs=None, **kwargs):
     matching_hints['func_coeff'] = func_coef
     matching_hints['is_linear'] = is_linear
 
+    type_of_equation = None
+
     if len(set(order.values())) == 1:
         order_eq = list(matching_hints['order'].values())[0]
         if matching_hints['is_linear']:
-            type_of_equation = None
             if order_eq == 1:
-                # TODO: seperate hint for real?
                 type_of_equation = check_linear_order1_jordan(eq, funcs, func_coef)
 
             if type_of_equation is None:
@@ -1455,36 +1455,18 @@ def classify_sysode(eq, funcs=None, **kwargs):
                         type_of_equation = check_linear_2eq_order1(eq, funcs, func_coef)
                     elif order_eq == 2:
                         type_of_equation = check_linear_2eq_order2(eq, funcs, func_coef)
-                    else:
-                        type_of_equation = None
-
                 elif matching_hints['no_of_equation'] == 3:
                     if order_eq == 1:
                         type_of_equation = check_linear_3eq_order1(eq, funcs, func_coef)
                         if type_of_equation is None:
                             type_of_equation = check_linear_neq_order1(eq, funcs, func_coef)
-                    else:
-                        type_of_equation = None
-                else:
-                    if order_eq == 1:
-                        type_of_equation = check_linear_neq_order1(eq, funcs, func_coef)
-                    else:
-                        type_of_equation = None
         else:
             if matching_hints['no_of_equation'] == 2:
                 if order_eq == 1:
                     type_of_equation = check_nonlinear_2eq_order1(eq, funcs, func_coef)
-                else:
-                    type_of_equation = None
             elif matching_hints['no_of_equation'] == 3:
                 if order_eq == 1:
                     type_of_equation = check_nonlinear_3eq_order1(eq, funcs, func_coef)
-                else:
-                    type_of_equation = None
-            else:
-                type_of_equation = None
-    else:
-        type_of_equation = None
 
     matching_hints['type_of_equation'] = type_of_equation
 

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6309,6 +6309,27 @@ def lie_heuristic_linear(match, comp=False):
 
 
 def sysode_linear_order1_jordan(match_):
+    r"""System of n first-order constant-coefficient linear differential equations
+
+    .. math ::
+        M x' = L x + f(t)
+
+    Notes
+    =====
+
+    The nonhomogeneous case is not implemented yet.  Mass-matrix
+    assumed to be invertible and provided general solution uses the
+    Jordan canonical form for `A = M^{-1} L`, see [1]_.
+
+    References
+    ==========
+
+    .. [1] Ernst Hairer, Syvert Paul Nørsett, Gerhard Wanner.  Solving
+           Ordinary Differential Equations I.  Nonstiff Problems.
+           Springer Series in Comput. Mathematics, Vol. 8, Springer-Verlag 1987,
+           Second revised edition 1993, pp. 73-76.
+    """
+
     func = match_['func']
     fc = match_['func_coeff']
     eq = match_['eq']

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -6301,8 +6301,70 @@ def sysode_linear_order1_jordan(match_):
 
     A = M.inv()*L
     T, JJ = A.jordan_cells()
-    # FIXME: need special treatment for complex_conj pairs
-    expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
+
+    if all(a.is_extended_real for a in A):
+        # If matrix A is real: special treatment for conj pairs
+        def imag(q):
+            return (q - q.conjugate())/(2*I)
+
+        def real(q):
+            return (q + q.conjugate())/2
+
+        def extract_eigenvector_blocks(JJ, evs):
+            TT = []
+            c = 0
+            for J in JJ:
+                mult = J.rows
+                TT.append([evs.col(i) for i in range(c, c + mult)])
+                c = c + mult
+            assert len(TT) == len(JJ)
+            assert c == evs.cols
+            return TT
+
+        def make_exp_real_jordan_block(m, a, b, t, T):
+            R = Matrix([[cos(b*t), sin(b*t)], [-sin(b*t), cos(b*t)]])
+            expm = Matrix(2*m, 2*m, lambda r, c: 0)
+            for i in range(m):
+                for j in range(i, m):
+                    r = j - i
+                    expm[2*i:2*i+2, 2*j:2*j+2] = t**r/factorial(r)*R
+            expm = exp(a*t)*expm
+            T2 = []
+            for ev in T:
+                T2.extend([real(ev), imag(ev)])
+            return (expm, T2)
+
+        TT = extract_eigenvector_blocks(JJ, T)
+
+        # list of eigenvalues
+        ll = [J[0, 0] for J in JJ]
+
+        expm_list = []
+        ev_lol = []
+        for i in range(len(JJ)):
+            J = JJ[i]
+            evs = TT[i]
+            l = J[0, 0]
+            if l.is_complex and l.is_extended_real is False:
+                a, b = real(l), imag(l)
+                if b.is_positive:
+                    m = J.rows
+                    myexpm, myevs = make_exp_real_jordan_block(m, a, b, t, evs)
+                    expm_list.append(myexpm)
+                    ev_lol.append(myevs)
+            else:
+                expm_list.append((J*t).exp())
+                ev_lol.append(evs)
+        expm = Matrix(BlockDiagMatrix(*expm_list))
+
+        # rebuild matrix with eigenvector columns
+        T = Matrix(n, 0, [])
+        for evs in ev_lol:
+            for ev in evs:
+                T = T.row_join(ev)
+    else:
+        expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
+
     q = T*expm*T.inv()
     Cvec = Matrix(get_numbered_constants(eq, num=n))
     q = q*Cvec

--- a/sympy/solvers/ode.py
+++ b/sympy/solvers/ode.py
@@ -604,12 +604,9 @@ def dsolve(eq, func=None, hint="default", simplify=True,
             raise NotImplementedError
         else:
             if match['is_linear']:
-                # TODO: use 'hint', c.f., scalar case
-                if match['type_of_equation'] == 'linear_order1_jordan':
-                    solvefunc = globals()['sysode_%(type_of_equation)s' % match]
-                elif match['no_of_equation'] > 3:
+                if match['type_of_equation'] == 'type1' and match['order'] == 1:
                     solvefunc = globals()['sysode_linear_neq_order%(order)s' % match]
-                else:
+                elif match['no_of_equation'] <= 3:
                     solvefunc = globals()['sysode_linear_%(no_of_equation)seq_order%(order)s' % match]
             else:
                 solvefunc = globals()['sysode_nonlinear_%(no_of_equation)seq_order%(order)s' % match]
@@ -1447,7 +1444,7 @@ def classify_sysode(eq, funcs=None, **kwargs):
         order_eq = list(matching_hints['order'].values())[0]
         if matching_hints['is_linear']:
             if order_eq == 1:
-                type_of_equation = check_linear_order1_jordan(eq, funcs, func_coef)
+                type_of_equation = check_linear_neq_order1(eq, funcs, func_coef)
 
             if type_of_equation is None:
                 if matching_hints['no_of_equation'] == 2:
@@ -1458,8 +1455,6 @@ def classify_sysode(eq, funcs=None, **kwargs):
                 elif matching_hints['no_of_equation'] == 3:
                     if order_eq == 1:
                         type_of_equation = check_linear_3eq_order1(eq, funcs, func_coef)
-                        if type_of_equation is None:
-                            type_of_equation = check_linear_neq_order1(eq, funcs, func_coef)
         else:
             if matching_hints['no_of_equation'] == 2:
                 if order_eq == 1:
@@ -1471,34 +1466,6 @@ def classify_sysode(eq, funcs=None, **kwargs):
     matching_hints['type_of_equation'] = type_of_equation
 
     return matching_hints
-
-
-def check_linear_order1_jordan(eq, func, func_coef):
-    n = len(eq)
-    fc = func_coef
-    t = func[0].args[0]
-
-    M = Matrix(n, n, lambda i, j: +fc[i, func[j], 1])
-    L = Matrix(n, n, lambda i, j: -fc[i, func[j], 0])
-
-    if M.has(t) or L.has(t):
-        return
-
-    r = {'M': M, 'L': L}
-    try:
-        r['Minv'] = M.inv()
-    except ValueError:  # pragma: no cover
-        return
-
-    r['forcing'] = [S.Zero]*n
-    for i in range(n):
-        for j in Add.make_args(eq[i]):
-            if not j.has(*func):
-                r['forcing'][i] += j
-    if any(not f.is_zero for f in r['forcing']):
-        return  # nonhomogeneous systems aren't supported, see sympy/sympy#9244
-
-    return 'linear_order1_jordan'
 
 
 def check_linear_2eq_order1(eq, func, func_coef):
@@ -1738,19 +1705,30 @@ def check_linear_3eq_order1(eq, func, func_coef):
 
 
 def check_linear_neq_order1(eq, func, func_coef):
-    x = func[0].func
-    y = func[1].func
-    z = func[2].func
-    fc = func_coef
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
-    r = dict()
     n = len(eq)
+    fc = func_coef
+    t = func[0].args[0]
+
+    M = Matrix(n, n, lambda i, j: +fc[i, func[j], 1])
+    L = Matrix(n, n, lambda i, j: -fc[i, func[j], 0])
+
+    if M.has(t) or L.has(t):
+        return
+
+    r = {'M': M, 'L': L}
+    try:
+        r['Minv'] = M.inv()
+    except ValueError:  # pragma: no cover
+        return
+
+    r['forcing'] = [S.Zero]*n
     for i in range(n):
-        for j in range(n):
-            if (fc[i, func[j], 0]/fc[i, func[i], 1]).has(t):
-                return
-    if len(eq) == 3:
-        return 'type6'
+        for j in Add.make_args(eq[i]):
+            if not j.has(*func):
+                r['forcing'][i] += j
+    if any(not f.is_zero for f in r['forcing']):
+        return  # nonhomogeneous systems aren't supported, see sympy/sympy#9244
+
     return 'type1'
 
 
@@ -6308,49 +6286,6 @@ def lie_heuristic_linear(match, comp=False):
             return [{xi: xival, eta: etaval}]
 
 
-def sysode_linear_order1_jordan(match_):
-    r"""System of n first-order constant-coefficient linear differential equations
-
-    .. math ::
-        M x' = L x + f(t)
-
-    Notes
-    =====
-
-    The nonhomogeneous case is not implemented yet.  Mass-matrix
-    assumed to be invertible and provided general solution uses the
-    Jordan canonical form for `A = M^{-1} L`, see [1]_.
-
-    References
-    ==========
-
-    .. [1] Ernst Hairer, Syvert Paul Nørsett, Gerhard Wanner.  Solving
-           Ordinary Differential Equations I.  Nonstiff Problems.
-           Springer Series in Comput. Mathematics, Vol. 8, Springer-Verlag 1987,
-           Second revised edition 1993, pp. 73-76.
-    """
-
-    func = match_['func']
-    fc = match_['func_coeff']
-    eq = match_['eq']
-    n = len(eq)
-    t = func[0].args[0]
-
-    M = Matrix(n, n, lambda i, j: +fc[i, func[j], 1])
-    L = Matrix(n, n, lambda i, j: -fc[i, func[j], 0])
-
-    A = M.inv()*L
-    T, JJ = A.jordan_cells()
-    T, Tinv = map(simplify, [T, T.inv()])
-
-    expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
-    q = T*expm*Tinv
-    Cvec = Matrix(get_numbered_constants(eq, num=n))
-    q = q*Cvec
-
-    return [Eq(func[i], q[i]) for i in range(n)]
-
-
 def sysode_linear_2eq_order1(match_):
     C1, C2, C3, C4 = symbols('C1:5')
     x = match_['func'][0].func
@@ -7662,126 +7597,50 @@ def _linear_3eq_order1_type4(x, y, z, t, r):
 
 def sysode_linear_neq_order1(match_):
     sol = _linear_neq_order1_type1(match_)
+    return sol
 
 
 def _linear_neq_order1_type1(match_):
-    r"""
-    System of n first-order constant-coefficient linear nonhomogeneous differential equation
+    r"""System of n first-order constant-coefficient linear differential equations
 
-    .. math:: y'_k = a_{k1} y_1 + a_{k2} y_2 +...+ a_{kn} y_n; k = 1,2,...,n
+    .. math ::
+        M x' = L x + f(t)
 
-    or that can be written as `\vec{y'} = A . \vec{y}`
-    where `\vec{y}` is matrix of `y_k` for `k = 1,2,...n` and `A` is a `n \times n` matrix.
+    Notes
+    =====
 
-    Since these equations are equivalent to a first order homogeneous linear
-    differential equation. So the general solution will contain `n` linearly
-    independent parts and solution will consist some type of exponential
-    functions. Assuming `y = \vec{v} e^{rt}` is a solution of the system where
-    `\vec{v}` is a vector of coefficients of `y_1,...,y_n`. Substituting `y` and
-    `y' = r v e^{r t}` into the equation `\vec{y'} = A . \vec{y}`, we get
+    The nonhomogeneous case is not implemented yet.  Mass-matrix
+    assumed to be invertible and provided general solution uses the
+    Jordan canonical form for `A = M^{-1} L`, see [1]_.
 
-    .. math:: r \vec{v} e^{rt} = A \vec{v} e^{rt}
+    References
+    ==========
 
-    .. math:: r \vec{v} = A \vec{v}
-
-    where `r` comes out to be eigenvalue of `A` and vector `\vec{v}` is the eigenvector
-    of `A` corresponding to `r`. There are three possibilities of eigenvalues of `A`
-
-    - `n` distinct real eigenvalues
-    - complex conjugate eigenvalues
-    - eigenvalues with multiplicity `k`
-
-    1. When all eigenvalues `r_1,..,r_n` are distinct with `n` different eigenvectors
-    `v_1,...v_n` then the solution is given by
-
-    .. math:: \vec{y} = C_1 e^{r_1 t} \vec{v_1} + C_2 e^{r_2 t} \vec{v_2} +...+ C_n e^{r_n t} \vec{v_n}
-
-    where `C_1,C_2,...,C_n` are arbitrary constants.
-
-    2. When some eigenvalues are complex then in order to make the solution real,
-    we take a linear combination: if `r = a + bi` has an eigenvector
-    `\vec{v} = \vec{w_1} + i \vec{w_2}` then to obtain real-valued solutions to
-    the system, replace the complex-valued solutions `e^{rx} \vec{v}`
-    with real-valued solution `e^{ax} (\vec{w_1} \cos(bx) - \vec{w_2} \sin(bx))`
-    and for `r = a - bi` replace the solution `e^{-r x} \vec{v}` with
-    `e^{ax} (\vec{w_1} \sin(bx) + \vec{w_2} \cos(bx))`
-
-    3. If some eigenvalues are repeated. Then we get fewer than `n` linearly
-    independent eigenvectors, we miss some of the solutions and need to
-    construct the missing ones. We do this via generalized eigenvectors, vectors
-    which are not eigenvectors but are close enough that we can use to write
-    down the remaining solutions. For a eigenvalue `r` with eigenvector `\vec{w}`
-    we obtain `\vec{w_2},...,\vec{w_k}` using
-
-    .. math:: (A - r I) . \vec{w_2} = \vec{w}
-
-    .. math:: (A - r I) . \vec{w_3} = \vec{w_2}
-
-    .. math:: \vdots
-
-    .. math:: (A - r I) . \vec{w_k} = \vec{w_{k-1}}
-
-    Then the solutions to the system for the eigenspace are `e^{rt} [\vec{w}],
-    e^{rt} [t \vec{w} + \vec{w_2}], e^{rt} [\frac{t^2}{2} \vec{w} + t \vec{w_2} + \vec{w_3}],
-    ...,e^{rt} [\frac{t^{k-1}}{(k-1)!} \vec{w} + \frac{t^{k-2}}{(k-2)!} \vec{w_2} +...+ t \vec{w_{k-1}}
-    + \vec{w_k}]`
-
-    So, If `\vec{y_1},...,\vec{y_n}` are `n` solution of obtained from three
-    categories of `A`, then general solution to the system `\vec{y'} = A . \vec{y}`
-
-    .. math:: \vec{y} = C_1 \vec{y_1} + C_2 \vec{y_2} + \cdots + C_n \vec{y_n}
-
+    .. [1] Ernst Hairer, Syvert Paul Nørsett, Gerhard Wanner.  Solving
+           Ordinary Differential Equations I.  Nonstiff Problems.
+           Springer Series in Comput. Mathematics, Vol. 8, Springer-Verlag 1987,
+           Second revised edition 1993, pp. 73-76.
     """
-    eq = match_['eq']
+
     func = match_['func']
     fc = match_['func_coeff']
+    eq = match_['eq']
     n = len(eq)
-    t = list(list(eq[0].atoms(Derivative))[0].atoms(Symbol))[0]
-    constants = numbered_symbols(prefix='C', cls=Symbol, start=1)
-    M = Matrix(n, n, lambda i, j: -fc[i, func[j], 0])
-    evector = M.eigenvects(simplify=True)
+    t = func[0].args[0]
 
-    def is_complex(mat, root):
-        return Matrix(n, 1, lambda i, j: re(mat[i])*cos(im(root)*t) - im(mat[i])*sin(im(root)*t))
+    M = Matrix(n, n, lambda i, j: +fc[i, func[j], 1])
+    L = Matrix(n, n, lambda i, j: -fc[i, func[j], 0])
 
-    def is_complex_conjugate(mat, root):
-        return Matrix(n, 1, lambda i, j: re(mat[i])*sin(abs(im(root))*t) + im(mat[i])*cos(im(root)*t)*abs(im(root))/im(root))
+    A = M.inv()*L
+    T, JJ = A.jordan_cells()
+    T, Tinv = map(simplify, [T, T.inv()])
 
-    conjugate_root = []
-    e_vector = zeros(n, 1)
-    for evects in evector:
-        if evects[0] not in conjugate_root:
-            # If number of column of an eigenvector is not equal to the multiplicity
-            # of its eigenvalue then the legt eigenvectors are calculated
-            if len(evects[2]) != evects[1]:
-                var_mat = Matrix(n, 1, lambda i, j: Symbol('x' + str(i)))
-                Mnew = (M - evects[0]*eye(evects[2][-1].rows))*var_mat
-                w = [0 for i in range(evects[1])]
-                w[0] = evects[2][-1]
-                for r in range(1, evects[1]):
-                    w_ = Mnew - w[r-1]
-                    sol_dict = solve(list(w_), var_mat[1:])
-                    sol_dict[var_mat[0]] = var_mat[0]
-                    for key, value in sol_dict.items():
-                        sol_dict[key] = value.subs(var_mat[0], 1)
-                    w[r] = Matrix(n, 1, lambda i, j: sol_dict[var_mat[i]])
-                    evects[2].append(w[r])
-            for i in range(evects[1]):
-                C = next(constants)
-                for j in range(i+1):
-                    if evects[0].has(I):
-                        evects[2][j] = simplify(evects[2][j])
-                        e_vector += C*is_complex(evects[2][j], evects[0])*t**(i-j)*exp(re(evects[0])*t)/factorial(i-j)
-                        C = next(constants)
-                        e_vector += C*is_complex_conjugate(evects[2][j], evects[0])*t**(i-j)*exp(re(evects[0])*t)/factorial(i-j)
-                    else:
-                        e_vector += C*evects[2][j]*t**(i-j)*exp(evects[0]*t)/factorial(i-j)
-            if evects[0].has(I):
-                conjugate_root.append(conjugate(evects[0]))
-    sol = []
-    for i in range(len(eq)):
-        sol.append(Eq(func[i], e_vector[i]))
-    return sol
+    expm = Matrix(BlockDiagMatrix(*[(J*t).exp() for J in JJ]))
+    q = T*expm*Tinv
+    Cvec = Matrix(get_numbered_constants(eq, num=n))
+    q = q*Cvec
+
+    return [Eq(func[i], q[i]) for i in range(n)]
 
 
 def sysode_nonlinear_2eq_order1(match_):

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -3,8 +3,8 @@ import os
 import pytest
 
 from sympy import (acos, acosh, asinh, atan, cos, Derivative, diff, dsolve,
-                   Dummy, Eq, erf, erfi, exp, Function, I, Integral, LambertW,
-                   log, O, pi, Rational, RootOf, simplify, sin, sqrt, sstr,
+                   Dummy, Eq, erf, erfi, exp, Function, I, E, Integral, LambertW,
+                   Pow, log, O, pi, Rational, RootOf, simplify, sin, sqrt, sstr,
                    Symbol, tan, asin, sinh, Piecewise, symbols, Poly, Integer)
 from sympy.solvers.ode import (_undetermined_coefficients_match, checkodesol,
                                classify_ode, classify_sysode, constant_renumber,
@@ -34,19 +34,15 @@ def test_linear_2eq_order1():
     t, a = symbols('t, a')
     x0, y0 = symbols('x0, y0', cls=Function)
     eq1 = (Eq(diff(x(t), t), 9*y(t)), Eq(diff(y(t), t), 12*x(t)))
-    sol1 = [Eq(x(t), 9*C1*exp(-6*sqrt(3)*t) + 9*C2*exp(6*sqrt(3)*t)),
-    Eq(y(t), -6*sqrt(3)*C1*exp(-6*sqrt(3)*t) + 6*sqrt(3)*C2*exp(6*sqrt(3)*t))]
+    sol1 = [Eq(x(t), C1*(E**(6*sqrt(3)*t)/2 + E**(-6*sqrt(3)*t)/2) + C2*(sqrt(3)*E**(6*sqrt(3)*t)/4 - sqrt(3)*E**(-6*sqrt(3)*t)/4)), Eq(y(t), C1*(sqrt(3)*E**(6*sqrt(3)*t)/3 - sqrt(3)*E**(-6*sqrt(3)*t)/3) + C2*(E**(6*sqrt(3)*t)/2 + E**(-6*sqrt(3)*t)/2))]
     assert dsolve(eq1) == sol1
 
     eq2 = (Eq(diff(x(t), t), 2*x(t) + 4*y(t)), Eq(diff(y(t), t), 12*x(t) + 41*y(t)))
-    sol2 = [Eq(x(t), 4*C1*exp(t*(-sqrt(1713)/2 + 43/2)) + 4*C2*exp(t*(sqrt(1713)/2 + 43/2))),
-    Eq(y(t), C1*(-sqrt(1713)/2 + 39/2)*exp(t*(-sqrt(1713)/2 + 43/2)) + C2*(39/2 +
-    sqrt(1713)/2)*exp(t*(sqrt(1713)/2 + 43/2)))]
+    sol2 = [Eq(x(t), C1*(-4*sqrt(1713)*E**(t*(-sqrt(1713) + 43)/2)*(-sqrt(1713)/24 - 13/8)/571 + 4*sqrt(1713)*E**(t*(sqrt(1713) + 43)/2)*(-13/8 + sqrt(1713)/24)/571) + C2*(E**(t*(-sqrt(1713) + 43)/2)*(-sqrt(1713)/24 - 13/8)*(-13*sqrt(1713)/1142 + 1/2) + E**(t*(sqrt(1713) + 43)/2)*(-13/8 + sqrt(1713)/24)*(13*sqrt(1713)/1142 + 1/2))), Eq(y(t), C1*(-4*sqrt(1713)*E**(t*(-sqrt(1713) + 43)/2)/571 + 4*sqrt(1713)*E**(t*(sqrt(1713) + 43)/2)/571) + C2*(E**(t*(-sqrt(1713) + 43)/2)*(-13*sqrt(1713)/1142 + 1/2) + E**(t*(sqrt(1713) + 43)/2)*(13*sqrt(1713)/1142 + 1/2)))]
     assert dsolve(eq2) == sol2
 
     eq3 = (Eq(diff(x(t), t), x(t) + y(t)), Eq(diff(y(t), t), -2*x(t) + 2*y(t)))
-    sol3 = [Eq(x(t), (C1*sin(sqrt(7)*t/2) + C2*cos(sqrt(7)*t/2))*exp(3*t/2)),
-    Eq(y(t), ((C1/2 - sqrt(7)*C2/2)*sin(sqrt(7)*t/2) + (sqrt(7)*C1/2 + C2/2)*cos(sqrt(7)*t/2))*exp(3*t/2))]
+    sol3 = [Eq(x(t), C1*(-2*sqrt(7)*E**(t*(3 - sqrt(7)*I)/2)*I*(1/4 + sqrt(7)*I/4)/7 + 2*sqrt(7)*E**(t*(3 + sqrt(7)*I)/2)*I*(1/4 - sqrt(7)*I/4)/7) + C2*(E**(t*(3 - sqrt(7)*I)/2)*(1/4 + sqrt(7)*I/4)*(1/2 + sqrt(7)*I/14) + E**(t*(3 + sqrt(7)*I)/2)*(1/4 - sqrt(7)*I/4)*(1/2 - sqrt(7)*I/14))), Eq(y(t), C1*(-2*sqrt(7)*E**(t*(3 - sqrt(7)*I)/2)*I/7 + 2*sqrt(7)*E**(t*(3 + sqrt(7)*I)/2)*I/7) + C2*(E**(t*(3 - sqrt(7)*I)/2)*(1/2 + sqrt(7)*I/14) + E**(t*(3 + sqrt(7)*I)/2)*(1/2 - sqrt(7)*I/14)))]
     assert dsolve(eq3) == sol3
 
     eq4 = (Eq(diff(x(t), t), x(t) + y(t) + 9), Eq(diff(y(t), t), 2*x(t) + 5*y(t) + 23))
@@ -70,10 +66,7 @@ def test_linear_2eq_order1():
     assert dsolve(eq7) == sol7
 
     eq8 = (Eq(diff(x(t), t), 5*t*x(t) + t**2*y(t)), Eq(diff(y(t), t), -t**2*x(t) + (5*t+9*t**2)*y(t)))
-    sol8 = [Eq(x(t), (C1*exp((-sqrt(77)/2 + 9/2)*Integral(t**2, t)) +
-    C2*exp((sqrt(77)/2 + 9/2)*Integral(t**2, t)))*exp(Integral(5*t, t))),
-    Eq(y(t), (C1*(-sqrt(77)/2 + 9/2)*exp((-sqrt(77)/2 + 9/2)*Integral(t**2, t)) +
-    C2*(sqrt(77)/2 + 9/2)*exp((sqrt(77)/2 + 9/2)*Integral(t**2, t)))*exp(Integral(5*t, t)))]
+    sol8 = [Eq(x(t), E**Integral(5*t, t)*(C1*(sqrt(77)*E**((-sqrt(77) + 9)*Integral(t**2, t)/2)*(sqrt(77)/2 + 9/2)/77 - sqrt(77)*E**((sqrt(77) + 9)*Integral(t**2, t)/2)*(-sqrt(77)/2 + 9/2)/77) + C2*(E**((-sqrt(77) + 9)*Integral(t**2, t)/2)*(-9*sqrt(77)/154 + 1/2)*(sqrt(77)/2 + 9/2) + E**((sqrt(77) + 9)*Integral(t**2, t)/2)*(1/2 + 9*sqrt(77)/154)*(-sqrt(77)/2 + 9/2)))), Eq(y(t), E**Integral(5*t, t)*(C1*(sqrt(77)*E**((-sqrt(77) + 9)*Integral(t**2, t)/2)/77 - sqrt(77)*E**((sqrt(77) + 9)*Integral(t**2, t)/2)/77) + C2*(E**((-sqrt(77) + 9)*Integral(t**2, t)/2)*(-9*sqrt(77)/154 + 1/2) + E**((sqrt(77) + 9)*Integral(t**2, t)/2)*(1/2 + 9*sqrt(77)/154))))]
     assert dsolve(eq8) == sol8
 
     eq10 = (Eq(diff(x(t), t), 5*t*x(t) + t**2*y(t)), Eq(diff(y(t), t), (1-t**2)*x(t) + (5*t+9*t**2)*y(t)))
@@ -106,10 +99,8 @@ def test_linear_2eq_order1_type2_degen():
          Eq(diff(g(x), x), f(x) + 7)]
     s1 = [Eq(f(x), C2*exp(x) - 5), Eq(g(x), C2*exp(x) - C1 + 2*x - 5)]
     s = dsolve(e)
+    assert checksysodesol(e, s) == (True, [0, 0])
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
 
 def test_dsolve_linear_2eq_order1_diag_triangular():
@@ -117,30 +108,23 @@ def test_dsolve_linear_2eq_order1_diag_triangular():
          Eq(diff(g(x), x), g(x))]
     s1 = [Eq(f(x), C1*exp(x)), Eq(g(x), C2*exp(x))]
     s = dsolve(e)
+    assert checksysodesol(e, s) == (True, [0, 0])
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
     e = [Eq(diff(f(x), x), 2*f(x)),
          Eq(diff(g(x), x), 3*f(x) + 7*g(x))]
-    s1 = [Eq(f(x), -5*C1*exp(2*x)),
-          Eq(g(x), 3*C1*exp(2*x) + 8*C2*exp(7*x))]
+    s1 = [Eq(f(x), exp(2*x)*C1),
+          Eq(g(x), exp(7*x)*C2 + C1*(3*exp(7*x)/5 - 3*exp(2*x)/5))]
     s = dsolve(e)
+    assert checksysodesol(e, s) == (True, [0, 0])
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
 
 def test_sysode_linear_2eq_order1_type1_D_lt_0():
     e = [Eq(diff(f(x), x), -9*I*f(x) - 4*g(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
     s = dsolve(e)
-    s = [(l.lhs, l.rhs) for l in s]
-    # bit of a hassle to get these to clean up
-    assert (e[0].lhs - e[0].rhs).subs(s).doit().simplify().doit() == 0
-    assert (e[1].lhs - e[1].rhs).subs(s).doit().simplify().doit() == 0
+    assert checksysodesol(e, s) == (True, [0, 0])
 
 
 def test_sysode_linear_2eq_order1_type1_D_lt_0_b_eq_0():
@@ -148,10 +132,8 @@ def test_sysode_linear_2eq_order1_type1_D_lt_0_b_eq_0():
          Eq(diff(g(x), x), -4*I*g(x))]
     s1 = [Eq(f(x), C1*exp(-9*I*x)), Eq(g(x), C2*exp(-4*I*x))]
     s = dsolve(e)
+    assert checksysodesol(e, s) == (True, [0, 0])
     assert s == s1
-    s = [(l.lhs, l.rhs) for l in s]
-    assert e[0].subs(s).doit()
-    assert e[1].subs(s).doit()
 
 
 def test_linear_2eq_order2():
@@ -302,43 +284,29 @@ def test_linear_3eq_order1():
     x, y, z = symbols('x, y, z', cls=Function)
     t = Symbol('t')
     eq1 = (Eq(diff(x(t), t), 21*x(t)), Eq(diff(y(t), t), 17*x(t)+3*y(t)), Eq(diff(z(t), t), 5*x(t)+7*y(t)+9*z(t)))
-    sol1 = [Eq(x(t), C1*exp(21*t)), Eq(y(t), 17*C1*exp(21*t)/18 + C2*exp(3*t)),
-    Eq(z(t), 209*C1*exp(21*t)/216 - 7*C2*exp(3*t)/6 + C3*exp(9*t))]
+    sol1 = [Eq(x(t), E**(21*t)*C1), Eq(y(t), E**(3*t)*C2 + C1*(17*E**(21*t)/18 - 17*E**(3*t)/18)), Eq(z(t), E**(9*t)*C3 + C1*(209*E**(21*t)/216 - 149*E**(9*t)/72 + 119*E**(3*t)/108) + C2*(7*E**(9*t)/6 - 7*E**(3*t)/6))]
     assert dsolve(eq1) == sol1
 
     eq2 = (Eq(diff(x(t), t), 3*y(t)-11*z(t)), Eq(diff(y(t), t), 7*z(t)-3*x(t)), Eq(diff(z(t), t), 11*x(t)-7*y(t)))
-    sol2 = [Eq(x(t), 7*C0 + sqrt(179)*C1*cos(sqrt(179)*t) + (77*C1/3 + 130*C2/3)*sin(sqrt(179)*t)),
-    Eq(y(t), 11*C0 + sqrt(179)*C2*cos(sqrt(179)*t) + (-58*C1/3 - 77*C2/3)*sin(sqrt(179)*t)),
-    Eq(z(t), 3*C0 + sqrt(179)*(-7*C1/3 - 11*C2/3)*cos(sqrt(179)*t) + (11*C1 - 7*C2)*sin(sqrt(179)*t))]
+    sol2 = [Eq(x(t), C1*(E**(sqrt(179)*I*t)*(-21/170 + 11*sqrt(179)*I/170)*(-21/358 - 11*sqrt(179)*I/358) + 49/179 + E**(-sqrt(179)*I*t)*(-21/170 - 11*sqrt(179)*I/170)*(-21/358 + 11*sqrt(179)*I/358)) + C2*(E**(sqrt(179)*I*t)*(-21/170 + 11*sqrt(179)*I/170)*(-33/358 + 7*sqrt(179)*I/358) + 77/179 + E**(-sqrt(179)*I*t)*(-21/170 - 11*sqrt(179)*I/170)*(-33/358 - 7*sqrt(179)*I/358)) + C3*(85*E**(sqrt(179)*I*t)*(-21/170 + 11*sqrt(179)*I/170)/179 + 21/179 + 85*E**(-sqrt(179)*I*t)*(-21/170 - 11*sqrt(179)*I/170)/179)), Eq(y(t), C1*(E**(sqrt(179)*I*t)*(-33/170 - 7*sqrt(179)*I/170)*(-21/358 - 11*sqrt(179)*I/358) + 77/179 + E**(-sqrt(179)*I*t)*(-33/170 + 7*sqrt(179)*I/170)*(-21/358 + 11*sqrt(179)*I/358)) + C2*(E**(sqrt(179)*I*t)*(-33/170 - 7*sqrt(179)*I/170)*(-33/358 + 7*sqrt(179)*I/358) + 121/179 + E**(-sqrt(179)*I*t)*(-33/170 + 7*sqrt(179)*I/170)*(-33/358 - 7*sqrt(179)*I/358)) + C3*(85*E**(sqrt(179)*I*t)*(-33/170 - 7*sqrt(179)*I/170)/179 + 33/179 + 85*E**(-sqrt(179)*I*t)*(-33/170 + 7*sqrt(179)*I/170)/179)), Eq(z(t), C1*(E**(sqrt(179)*I*t)*(-21/358 - 11*sqrt(179)*I/358) + 21/179 + E**(-sqrt(179)*I*t)*(-21/358 + 11*sqrt(179)*I/358)) + C2*(E**(sqrt(179)*I*t)*(-33/358 + 7*sqrt(179)*I/358) + 33/179 + E**(-sqrt(179)*I*t)*(-33/358 - 7*sqrt(179)*I/358)) + C3*(85*E**(sqrt(179)*I*t)/179 + 9/179 + 85*E**(-sqrt(179)*I*t)/179))]
     assert dsolve(eq2) == sol2
 
     eq3 = (Eq(3*diff(x(t), t), 4*5*(y(t)-z(t))), Eq(4*diff(y(t), t), 3*5*(z(t)-x(t))), Eq(5*diff(z(t), t), 3*4*(x(t)-y(t))))
-    sol3 = [Eq(x(t), C0 + 5*sqrt(2)*C1*cos(5*sqrt(2)*t) + (12*C1/5 + 164*C2/15)*sin(5*sqrt(2)*t)),
-    Eq(y(t), C0 + 5*sqrt(2)*C2*cos(5*sqrt(2)*t) + (-51*C1/10 - 12*C2/5)*sin(5*sqrt(2)*t)),
-    Eq(z(t), C0 + 5*sqrt(2)*(-9*C1/25 - 16*C2/25)*cos(5*sqrt(2)*t) + (12*C1/5 - 12*C2/5)*sin(5*sqrt(2)*t))]
+    sol3 = [Eq(x(t), C1*(E**(5*sqrt(2)*I*t)*(-1 + 4*sqrt(2)*I/3)*(-9/100 - 3*sqrt(2)*I/25) + 9/50 + E**(-5*sqrt(2)*I*t)*(-1 - 4*sqrt(2)*I/3)*(-9/100 + 3*sqrt(2)*I/25)) + C2*(E**(5*sqrt(2)*I*t)*(-1 + 4*sqrt(2)*I/3)*(-4/25 + 3*sqrt(2)*I/25) + 8/25 + E**(-5*sqrt(2)*I*t)*(-1 - 4*sqrt(2)*I/3)*(-4/25 - 3*sqrt(2)*I/25)) + C3*(E**(5*sqrt(2)*I*t)*(-1 + 4*sqrt(2)*I/3)/4 + 1/2 + E**(-5*sqrt(2)*I*t)*(-1 - 4*sqrt(2)*I/3)/4)), Eq(y(t), C1*(E**(5*sqrt(2)*I*t)*(-1 - 3*sqrt(2)*I/4)*(-9/100 - 3*sqrt(2)*I/25) + 9/50 + E**(-5*sqrt(2)*I*t)*(-1 + 3*sqrt(2)*I/4)*(-9/100 + 3*sqrt(2)*I/25)) + C2*(E**(5*sqrt(2)*I*t)*(-1 - 3*sqrt(2)*I/4)*(-4/25 + 3*sqrt(2)*I/25) + 8/25 + E**(-5*sqrt(2)*I*t)*(-1 + 3*sqrt(2)*I/4)*(-4/25 - 3*sqrt(2)*I/25)) + C3*(E**(5*sqrt(2)*I*t)*(-1 - 3*sqrt(2)*I/4)/4 + 1/2 + E**(-5*sqrt(2)*I*t)*(-1 + 3*sqrt(2)*I/4)/4)), Eq(z(t), C1*(E**(5*sqrt(2)*I*t)*(-9/100 - 3*sqrt(2)*I/25) + 9/50 + E**(-5*sqrt(2)*I*t)*(-9/100 + 3*sqrt(2)*I/25)) + C2*(E**(5*sqrt(2)*I*t)*(-4/25 + 3*sqrt(2)*I/25) + 8/25 + E**(-5*sqrt(2)*I*t)*(-4/25 - 3*sqrt(2)*I/25)) + C3*(E**(5*sqrt(2)*I*t)/4 + 1/2 + E**(-5*sqrt(2)*I*t)/4))]
     assert dsolve(eq3) == sol3
 
     f = t**3 + log(t)
     g = t**2 + sin(t)
     eq4 = (Eq(diff(x(t), t), (4*f+g)*x(t)-f*y(t)-2*f*z(t)), Eq(diff(y(t), t), 2*f*x(t)+(f+g)*y(t)-2*f*z(t)), Eq(diff(z(t), t), 5*f*x(t)+f*y(t)+(-3*f+g)*z(t)))
-    sol4 = [Eq(x(t), (C1*exp(-2*Integral(t**3 + log(t), t)) + C2*(sqrt(3)*sin(sqrt(3)*Integral(t**3 + log(t), t))/6
-    + cos(sqrt(3)*Integral(t**3 + log(t), t))/2) + C3*(sin(sqrt(3)*Integral(t**3 + log(t), t))/2 -
-    sqrt(3)*cos(sqrt(3)*Integral(t**3 + log(t), t))/6))*exp(Integral(-t**2 - sin(t), t))), Eq(y(t),
-    (C2*(sqrt(3)*sin(sqrt(3)*Integral(t**3 + log(t), t))/6 + cos(sqrt(3)*Integral(t**3 + log(t), t))/2) +
-    C3*(sin(sqrt(3)*Integral(t**3 + log(t), t))/2 - sqrt(3)*cos(sqrt(3)*Integral(t**3 + log(t), t))/6)) *
-    exp(Integral(-t**2 - sin(t), t))), Eq(z(t), (C1*exp(-2*Integral(t**3 + log(t), t)) + C2*cos(sqrt(3) *
-    Integral(t**3 + log(t), t)) + C3*sin(sqrt(3)*Integral(t**3 + log(t), t)))*exp(Integral(-t**2 - sin(t), t)))]
+    sol4 = [Eq(x(t), E**Integral(-t**2 - sin(t), t)*(C1*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(-1/2 + sqrt(3)*I/2)*(1/2 - sqrt(3)*I/6) + E**(-2*Integral(t**3 + log(t), t)) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(-1/2 - sqrt(3)*I/2)*(1/2 + sqrt(3)*I/6)) + C2*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/6)*(1/2 + sqrt(3)*I/2) - E**(-2*Integral(t**3 + log(t), t)) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/2)*(1/2 + sqrt(3)*I/6)) + C3*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/2)*(1/2 - sqrt(3)*I/6) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 + sqrt(3)*I/6)*(1/2 + sqrt(3)*I/2)))), Eq(y(t), E**Integral(-t**2 - sin(t), t)*(C1*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(-1/2 + sqrt(3)*I/2)*(1/2 - sqrt(3)*I/6) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(-1/2 - sqrt(3)*I/2)*(1/2 + sqrt(3)*I/6)) + C2*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/6)*(1/2 + sqrt(3)*I/2) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/2)*(1/2 + sqrt(3)*I/6)) + C3*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/2)*(1/2 - sqrt(3)*I/6) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 + sqrt(3)*I/6)*(1/2 + sqrt(3)*I/2)))), Eq(z(t), E**Integral(-t**2 - sin(t), t)*(C1*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(-1/2 + sqrt(3)*I/2) + E**(-2*Integral(t**3 + log(t), t)) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(-1/2 - sqrt(3)*I/2)) + C2*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 + sqrt(3)*I/2) - E**(-2*Integral(t**3 + log(t), t)) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/2)) + C3*(E**(sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 - sqrt(3)*I/2) + E**(-sqrt(3)*I*Integral(t**3 + log(t), t))*(1/2 + sqrt(3)*I/2))))]
     assert dsolve(eq4) == sol4
 
     eq5 = (Eq(diff(x(t), t), 4*x(t) - z(t)), Eq(diff(y(t), t), 2*x(t)+2*y(t)-z(t)), Eq(diff(z(t), t), 3*x(t)+y(t)))
-    sol5 = [Eq(x(t), C1*exp(2*t) + C2*t*exp(2*t) + C2*exp(2*t) + C3*t**2*exp(2*t)/2 + C3*t*exp(2*t) + C3*exp(2*t)),
-    Eq(y(t), C1*exp(2*t) + C2*t*exp(2*t) + C2*exp(2*t) + C3*t**2*exp(2*t)/2 + C3*t*exp(2*t)),
-    Eq(z(t), 2*C1*exp(2*t) + 2*C2*t*exp(2*t) + C2*exp(2*t) + C3*t**2*exp(2*t) + C3*t*exp(2*t) + C3*exp(2*t))]
+    sol5 = [Eq(x(t), -E**(2*t)*C2*t**2/2 - E**(2*t)*C3*t + C1*(E**(2*t)*t**2/2 + 2*E**(2*t)*t + E**(2*t))), Eq(y(t), -E**(2*t)*C3*t + C1*(E**(2*t)*t**2/2 + 2*E**(2*t)*t) + C2*(-E**(2*t)*t**2/2 + E**(2*t))), Eq(z(t), C1*(E**(2*t)*t**2 + 3*E**(2*t)*t) + C2*(-E**(2*t)*t**2 + E**(2*t)*t) + C3*(-2*E**(2*t)*t + E**(2*t)))]
     assert dsolve(eq5) == sol5
 
     eq6 = (Eq(diff(x(t), t), 4*x(t) - y(t) - 2*z(t)), Eq(diff(y(t), t), 2*x(t) + y(t) - 2*z(t)), Eq(diff(z(t), t), 5*x(t)-3*z(t)))
-    sol6 = [Eq(x(t), C1*exp(2*t) + C2*(-sin(t) + 3*cos(t)) + C3*(3*sin(t) + cos(t))),
-    Eq(y(t), C2*(-sin(t) + 3*cos(t)) + C3*(3*sin(t) + cos(t))), Eq(z(t), C1*exp(2*t) + 5*C2*cos(t) + 5*C3*sin(t))]
+    sol6 = [Eq(x(t), C1*(E**(2*t) + E**(I*t)*(-1/2 - 3*I/2)*(3/5 + I/5) + E**(-I*t)*(-1/2 + 3*I/2)*(3/5 - I/5)) + C2*(-E**(2*t) + E**(I*t)*(1/2 - I)*(3/5 + I/5) + E**(-I*t)*(1/2 + I)*(3/5 - I/5)) + C3*(E**(I*t)*(1/2 + 3*I/2)*(3/5 + I/5) + E**(-I*t)*(1/2 - 3*I/2)*(3/5 - I/5))), Eq(y(t), C1*(E**(I*t)*(-1/2 - 3*I/2)*(3/5 + I/5) + E**(-I*t)*(-1/2 + 3*I/2)*(3/5 - I/5)) + C2*(E**(I*t)*(1/2 - I)*(3/5 + I/5) + E**(-I*t)*(1/2 + I)*(3/5 - I/5)) + C3*(E**(I*t)*(1/2 + 3*I/2)*(3/5 + I/5) + E**(-I*t)*(1/2 - 3*I/2)*(3/5 - I/5))), Eq(z(t), C1*(E**(2*t) + E**(I*t)*(-1/2 - 3*I/2) + E**(-I*t)*(-1/2 + 3*I/2)) + C2*(-E**(2*t) + E**(I*t)*(1/2 - I) + E**(-I*t)*(1/2 + I)) + C3*(E**(I*t)*(1/2 + 3*I/2) + E**(-I*t)*(1/2 - 3*I/2)))]
     assert dsolve(eq6) == sol6
 
 
@@ -825,7 +793,7 @@ def test_classify_sysode():
     sol9 = {'no_of_equation': 3, 'func_coeff': {(1, y(t), 0): 0, (2, y(t), 1): 0, (2, z(t), 1): 1,
     (0, x(t), 0): 0, (2, x(t), 1): 0, (1, x(t), 1): 0, (2, y(t), 0): 7, (0, x(t), 1): 1, (1, z(t), 1): 0,
     (0, y(t), 1): 0, (1, x(t), 0): 3, (0, z(t), 0): 11, (0, y(t), 0): -3, (1, z(t), 0): -7, (0, z(t), 1): 0,
-    (2, x(t), 0): -11, (2, z(t), 0): 0, (1, y(t), 1): 1}, 'type_of_equation': 'type2', 'func': [x(t), y(t), z(t)],
+    (2, x(t), 0): -11, (2, z(t), 0): 0, (1, y(t), 1): 1}, 'type_of_equation': 'type1', 'func': [x(t), y(t), z(t)],
     'is_linear': True, 'eq': [-3*y(t) + 11*z(t) + Derivative(x(t), t), 3*x(t) - 7*z(t) + Derivative(y(t), t),
     -11*x(t) + 7*y(t) + Derivative(z(t), t)], 'order': {z(t): 1, y(t): 1, x(t): 1}}
     assert classify_sysode(eq9) == sol9
@@ -872,7 +840,7 @@ def test_classify_sysode():
     sol15 = {'no_of_equation': 3, 'func_coeff': {(1, y(t), 0): -13, (2, y(t), 1): 0, (2, z(t), 1): 1,
     (0, x(t), 0): -4, (2, x(t), 1): 0, (1, x(t), 1): 0, (2, y(t), 0): -41, (0, x(t), 1): 1, (1, z(t), 1): 0,
     (0, y(t), 1): 0, (1, x(t), 0): -1, (0, z(t), 0): -2, (0, y(t), 0): -5, (1, z(t), 0): -9, (0, z(t), 1): 0,
-    (2, x(t), 0): -32, (2, z(t), 0): -11, (1, y(t), 1): 1}, 'type_of_equation': 'type6', 'func':
+    (2, x(t), 0): -32, (2, z(t), 0): -11, (1, y(t), 1): 1}, 'type_of_equation': 'type1', 'func':
     [x(t), y(t), z(t)], 'is_linear': True, 'eq': [-4*x(t) - 5*y(t) - 2*z(t) + Derivative(x(t), t), -x(t) - 13*y(t) -
     9*z(t) + Derivative(y(t), t), -32*x(t) - 41*y(t) - 11*z(t) + Derivative(z(t), t)], 'order': {z(t): 1, y(t): 1, x(t): 1}}
     assert classify_sysode(eq15) == sol15
@@ -881,7 +849,7 @@ def test_classify_sysode():
     sol16 = {'no_of_equation': 3, 'func_coeff': {(1, y(t), 0): 0, (2, y(t), 1): 0, (2, z(t), 1): 5,
     (0, x(t), 0): 0, (2, x(t), 1): 0, (1, x(t), 1): 0, (2, y(t), 0): 12, (0, x(t), 1): 3, (1, z(t), 1): 0,
     (0, y(t), 1): 0, (1, x(t), 0): 15, (0, z(t), 0): 20, (0, y(t), 0): -20, (1, z(t), 0): -15, (0, z(t), 1): 0,
-    (2, x(t), 0): -12, (2, z(t), 0): 0, (1, y(t), 1): 4}, 'type_of_equation': 'type3', 'func': [x(t), y(t), z(t)],
+    (2, x(t), 0): -12, (2, z(t), 0): 0, (1, y(t), 1): 4}, 'type_of_equation': 'type1', 'func': [x(t), y(t), z(t)],
     'is_linear': True, 'eq': [-20*y(t) + 20*z(t) + 3*Derivative(x(t), t), 15*x(t) - 15*z(t) + 4*Derivative(y(t), t),
     -12*x(t) + 12*y(t) + 5*Derivative(z(t), t)], 'order': {z(t): 1, y(t): 1, x(t): 1}}
     assert classify_sysode(eq16) == sol16

--- a/sympy/solvers/tests/test_ode.py
+++ b/sympy/solvers/tests/test_ode.py
@@ -115,7 +115,7 @@ def test_linear_2eq_order1_type2_degen():
 def test_dsolve_linear_2eq_order1_diag_triangular():
     e = [Eq(diff(f(x), x), f(x)),
          Eq(diff(g(x), x), g(x))]
-    s1 = [Eq(f(x), C2*exp(x)), Eq(g(x), C1*exp(x))]
+    s1 = [Eq(f(x), C1*exp(x)), Eq(g(x), C2*exp(x))]
     s = dsolve(e)
     assert s == s1
     s = [(l.lhs, l.rhs) for l in s]
@@ -133,7 +133,6 @@ def test_dsolve_linear_2eq_order1_diag_triangular():
     assert e[1].subs(s).doit()
 
 
-@pytest.mark.xfail
 def test_sysode_linear_2eq_order1_type1_D_lt_0():
     e = [Eq(diff(f(x), x), -9*I*f(x) - 4*g(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
@@ -144,7 +143,6 @@ def test_sysode_linear_2eq_order1_type1_D_lt_0():
     assert (e[1].lhs - e[1].rhs).subs(s).doit().simplify().doit() == 0
 
 
-@pytest.mark.xfail
 def test_sysode_linear_2eq_order1_type1_D_lt_0_b_eq_0():
     e = [Eq(diff(f(x), x), -9*I*f(x)),
          Eq(diff(g(x), x), -4*I*g(x))]
@@ -351,9 +349,8 @@ def test_linear_3eq_order1_nonhomog():
     pytest.raises(NotImplementedError, lambda: dsolve(e))
 
 
-@pytest.mark.xfail
 def test_linear_3eq_order1_diagonal():
-    # code makes assumptions about coefficients being nonzero, breaks when assumptions are not true
+    # older code made assumptions about coefficients being nonzero
     e = [Eq(diff(f(x), x), f(x)),
          Eq(diff(g(x), x), g(x)),
          Eq(diff(h(x), x), h(x))]
@@ -2665,6 +2662,8 @@ def test_issue_7093():
 def test_dsolve_linsystem_symbol():
     eps = Symbol('epsilon', positive=True)
     eq1 = (Eq(diff(f(x), x), -eps*g(x)), Eq(diff(g(x), x), eps*f(x)))
-    sol1 = [Eq(f(x), -eps*(C1*sin(eps*x) + C2*cos(eps*x))),
-            Eq(g(x), C1*eps*cos(eps*x) - C2*eps*sin(eps*x))]
-    assert dsolve(eq1) == sol1
+    sol1 = [Eq(f(x), C1*cos(eps*x) - C2*sin(eps*x)),
+            Eq(g(x), C2*cos(eps*x) + C1*sin(eps*x))]
+    s = dsolve(eq1)
+    assert checksysodesol(eq1, s) == (True, [0, 0])
+    assert [a.rewrite(Pow, cos).simplify() for a in s] == sol1


### PR DESCRIPTION
I hope @cbm755 ok if I continue [his work](https://github.com/sympy/sympy/pull/9235) here.

- [x] cleanup classify_sysode, drop redundant/untested code
- [x] cleanup tests/doctests
- [x] support mass matrix case, but see #293
- [x] don't simplify answer at all? (i.e. with sin/sinh)
- [x] drop unused sysode handlers, if any
- [x] good references (Hairer I?)
- [x] rename check_linear_order1_jordan-> check_linear_neq_order1,
       sysode_linear_order1_jordan -> sysode_linear_neq_order1
- [x] rebase