### PR TITLE
Add regression test for sympy/sympy#11526

### DIFF
--- a/diofant/core/add.py
+++ b/diofant/core/add.py
@@ -642,13 +642,9 @@ class Add(Expr, AssocOp):
         return self.func(*re_part), self.func(*im_part)
 
     def _eval_as_leading_term(self, x):
-        from diofant import expand_mul, factor_terms
+        from diofant import factor_terms
 
-        expr = expand_mul(self)
-        if not expr.is_Add:
-            return expr.as_leading_term(x)
-
-        expr = expr.func(*[t.as_leading_term(x) for t in expr.args]).removeO()
+        expr = self.func(*[t.as_leading_term(x) for t in self.args]).removeO()
         if not expr:
             # simple leading term analysis gave us 0 but we have to send
             # back a term, so compute the leading term (via series)

--- a/diofant/series/tests/test_limits.py
+++ b/diofant/series/tests/test_limits.py
@@ -6,11 +6,12 @@ import pytest
 from diofant import (limit, exp, oo, log, sqrt, Limit, sin, floor, cos,
                      acos, ceiling, atan, gamma, Symbol, S, pi, E, Integral,
                      cot, Rational, I, tan, integrate, Sum, sign, Piecewise,
-                     Function, subfactorial, PoleError, Integer, Float)
+                     Function, subfactorial, PoleError, Integer, Float,
+                     diff, simplify)
 from diofant.series.limits import heuristics
 from diofant.series.order import O
 
-from diofant.abc import a, c, x, y, z, n
+from diofant.abc import a, b, c, x, y, z, n
 
 
 def test_basic1():
@@ -475,3 +476,13 @@ def test_issue_6171():
     e = Piecewise((0, x < 0), (1, True))
     assert e.limit(x, 0) == 1
     assert e.limit(x, 0, "-") == 0
+
+
+def test_issue_11526():
+    df = diff(1/(a*log((x - b)/(x - c))), x)
+    res = -1/(-a*c + a*b)
+    assert limit(df, x, oo) == res
+    assert limit(simplify(df), x, oo) == res
+
+    e = log((1/x - b)/(1/x - c))
+    assert e.as_leading_term(x) == x*(c - b)


### PR DESCRIPTION
This also partially fix issues with
Add._eval_as_leading_term, mentioned by @jksuom.
Anyway, this expand_mul() call looks like a hack,
so I'll remove one.

Closes sympy/sympy#11526