### PR TITLE
Check & fix explicit assumption properties (i.e. is_real = False)

### DIFF
--- a/diofant/core/numbers.py
+++ b/diofant/core/numbers.py
@@ -616,8 +616,6 @@ class Float(Number):
 
     # A Float represents many real numbers,
     # both rational and irrational.
-    is_rational = None
-    is_irrational = None
     is_number = True
 
     is_extended_real = True
@@ -3077,7 +3075,6 @@ class EulerGamma(NumberSymbol, metaclass=Singleton):
     is_real = True
     is_positive = True
     is_negative = False
-    is_irrational = None
     is_number = True
 
     def _latex(self, printer):
@@ -3127,7 +3124,6 @@ class Catalan(NumberSymbol, metaclass=Singleton):
     is_real = True
     is_positive = True
     is_negative = False
-    is_irrational = None
     is_number = True
 
     def __int__(self):

--- a/diofant/functions/elementary/complexes.py
+++ b/diofant/functions/elementary/complexes.py
@@ -239,7 +239,6 @@ class sign(Function):
     diofant.functions.elementary.complexes.conjugate
     """
 
-    is_finite = True
     is_complex = True
 
     def doit(self, **hints):
@@ -562,8 +561,7 @@ class arg(Function):
     pi/4
     """
 
-    is_extended_real = True
-    is_finite = True
+    is_real = True
 
     @classmethod
     def eval(cls, arg):

--- a/diofant/functions/elementary/complexes.py
+++ b/diofant/functions/elementary/complexes.py
@@ -573,6 +573,8 @@ class arg(Function):
             arg_ = sign(c)*arg_
         else:
             arg_ = arg
+        if arg_.is_zero:
+            return S.Zero
         x, y = re(arg_), im(arg_)
         rv = atan2(y, x)
         if rv.is_number and not rv.atoms(AppliedUndef):

--- a/diofant/functions/elementary/tests/test_complexes.py
+++ b/diofant/functions/elementary/tests/test_complexes.py
@@ -468,7 +468,7 @@ def test_abs():
 
 
 def test_arg():
-    assert arg(0) == nan
+    assert arg(0) == 0
     assert arg(1) == 0
     assert arg(-1) == pi
     assert arg(I) == pi/2

--- a/diofant/functions/special/delta_functions.py
+++ b/diofant/functions/special/delta_functions.py
@@ -41,7 +41,7 @@ class DiracDelta(Function):
     .. [1] http://mathworld.wolfram.com/DeltaFunction.html
     """
 
-    is_extended_real = True
+    is_commutative = True
 
     def fdiff(self, argindex=1):
         if argindex == 1:
@@ -159,6 +159,15 @@ class DiracDelta(Function):
     @staticmethod
     def _latex_no_arg(printer):
         return r'\delta'
+
+    def _eval_adjoint(self):
+        return self
+
+    def _eval_conjugate(self):
+        return self
+
+    def _eval_transpose(self):
+        return self
 
 
 ###############################################################################

--- a/diofant/functions/special/delta_functions.py
+++ b/diofant/functions/special/delta_functions.py
@@ -184,8 +184,6 @@ class Heaviside(Function):
     .. [1] https://en.wikipedia.org/wiki/Heaviside_step_function
     """
 
-    is_real = True
-
     def fdiff(self, argindex=1):
         if argindex == 1:
             return DiracDelta(self.args[0])
@@ -211,3 +209,7 @@ class Heaviside(Function):
     def _eval_rewrite_as_sign(self, arg):
         if arg.is_extended_real:
             return (sign(arg)+1)/2
+
+    def _eval_is_real(self):
+        if self.args[0].is_extended_real:
+            return True

--- a/diofant/functions/special/tests/test_delta_functions.py
+++ b/diofant/functions/special/tests/test_delta_functions.py
@@ -45,10 +45,15 @@ def test_DiracDelta():
 
 
 def test_heaviside():
+    x, y = symbols('x, y', extended_real=True)
+    z = Symbol('z')
     assert Heaviside(0) == 0.5
     assert Heaviside(-5) == 0
     assert Heaviside(1) == 1
     assert Heaviside(nan) == nan
+
+    assert Heaviside(x).is_real
+    assert Heaviside(z).is_real is None
 
     assert adjoint(Heaviside(x)) == Heaviside(x)
     assert adjoint(Heaviside(x - y)) == Heaviside(x - y)
@@ -58,8 +63,8 @@ def test_heaviside():
     assert transpose(Heaviside(x - y)) == Heaviside(x - y)
 
     assert Heaviside(x).diff(x) == DiracDelta(x)
-    assert Heaviside(x + I).is_Function is True
-    assert Heaviside(I*x).is_Function is True
+    assert Heaviside(z + I).is_Function is True
+    assert Heaviside(I*z).is_Function is True
 
     pytest.raises(ArgumentIndexError, lambda: Heaviside(x).fdiff(2))
     pytest.raises(ValueError, lambda: Heaviside(I))

--- a/diofant/printing/tests/test_latex.py
+++ b/diofant/printing/tests/test_latex.py
@@ -340,10 +340,10 @@ def test_latex_functions():
     assert latex(Znm(n, m, theta, phi)**3) == r'\left(Z_{n}^{m}\left(\theta,\phi\right)\right)^{3}'
 
     # Test latex printing of function names with "_"
-    assert latex(
-        polar_lift(0)) == r"\operatorname{polar\_lift}{\left (0 \right )}"
-    assert latex(polar_lift(
-        0)**3) == r"\operatorname{polar\_lift}^{3}{\left (0 \right )}"
+    assert (latex(polar_lift(0, evaluate=False)) ==
+            r"\operatorname{polar\_lift}{\left (0 \right )}")
+    assert (latex(polar_lift(0, evaluate=False)**3) ==
+            r"\operatorname{polar\_lift}^{3}{\left (0 \right )}")
 
     assert latex(totient(n)) == r'\phi\left( n \right)'
 

--- a/diofant/stats/drv.py
+++ b/diofant/stats/drv.py
@@ -88,7 +88,6 @@ class SingleDiscreteDomain(SingleDomain):
 
 class SingleDiscretePSpace(SinglePSpace):
     """ Discrete probability space over a single univariate variable """
-    is_real = True
 
     @property
     def set(self):

--- a/diofant/stats/rv.py
+++ b/diofant/stats/rv.py
@@ -132,7 +132,6 @@ class PSpace(Basic):
 
     is_Finite = None
     is_Continuous = None
-    is_real = None
 
     @property
     def domain(self):

--- a/diofant/tensor/indexed.py
+++ b/diofant/tensor/indexed.py
@@ -320,7 +320,6 @@ class IndexedBase(Expr, NotIterable):
     (o, p)
 
     """
-    is_commutative = True
 
     def __new__(cls, label, shape=None, **kw_args):
         if isinstance(label, str):


### PR DESCRIPTION
 - [x] diofant/core/basic.py
 - [x] diofant/core/expr.py
 - [x] diofant/core/mul.py
 - [x] diofant/core/numbers.py
 - [x] diofant/core/operations.py
 - [x] diofant/core/symbol.py
 - [x] diofant/core/tests/test_priority.py
 - [x] diofant/diffgeom/diffgeom.py
 - [x] diofant/functions/elementary/complexes.py
 - [x] diofant/functions/elementary/exponential.py
 - [x] diofant/functions/special/delta_functions.py
 - [x] diofant/functions/special/hyper.py
 - [x] diofant/functions/special/tensor_functions.py
 - [x] diofant/matrices/expressions/matexpr.py
 - [x] diofant/polys/polytools.py
 - [x] diofant/polys/rootoftools.py
 - [x] diofant/polys/tests/test_partfrac.py
 - [x] diofant/polys/tests/test_polytools.py
 - [x] diofant/printing/tests/test_str.py
 - [x] diofant/stats/crv.py
 - [x] diofant/stats/drv.py
 - [x] diofant/stats/rv.py
 - [x] diofant/tensor/indexed.py
 - [x] diofant/tensor/tensor.py

List generated with ``git grep '^ *is_[a-z].*= '|egrep -v 'is_number|is_comparable|is_iterable|is_interval|is_open|is_linear|is_global|is_default|is_canon_|is_mat|is_conto|is_parame|is_impli|is_func|is_contr|is_newz|is_arg|is_group|is_symbol|is_equal|is_cycle|is_slice|is_str' | cut -f1 -d:|sort|uniq | xargs -n1 -I {} printf " - [ ] {}\n"``