### PR TITLE
Remove sorting from Add.flatten

### DIFF
--- a/diofant/core/add.py
+++ b/diofant/core/add.py
@@ -209,8 +209,14 @@ class Add(AssocOp):
         else:
             return newseq, [], None
 
+    @property
+    @cacheit
+    def _sorted_args(self):
+        return tuple(sorted(self._args, key=default_sort_key))
+
     def _hashable_content(self):
-        return frozenset(self.args),
+        from ..sets import Set
+        return Set(*self._args),
 
     @classmethod
     def class_key(cls):

--- a/diofant/core/add.py
+++ b/diofant/core/add.py
@@ -199,9 +199,6 @@ class Add(AssocOp):
                     coeff = S.Zero
                     break
 
-        # order args canonically
-        newseq.sort(key=default_sort_key)
-
         # current code expects coeff to be first
         if coeff is not S.Zero:
             newseq.insert(0, coeff)
@@ -211,6 +208,9 @@ class Add(AssocOp):
             return [], newseq, None
         else:
             return newseq, [], None
+
+    def _hashable_content(self):
+        return frozenset(self.args),
 
     @classmethod
     def class_key(cls):


### PR DESCRIPTION
Some primitive benchmarks:

``` python
In [1]: %time p = sum(x**i for i in range(500))
CPU times: user 25.7 s, sys: 1.32 s, total: 27 s
Wall time: 29.7 s
```

``` python
In [1]: %time p = sum(x**i for i in range(500))  # on the branch
CPU times: user 1.88 s, sys: 20 ms, total: 1.9 s
Wall time: 2.05 s
```
