### PR TITLE
Run printing setup on (interactive) session startup

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -40,10 +40,6 @@ def check_disabled(request):
 @pytest.fixture(autouse=True, scope='session')
 def set_displayhook():
     import sys
-    from diofant import init_printing
-
-    # hook our nice, hash-stable strprinter
-    init_printing(pretty_print=False, use_unicode=False)
 
     # doctest restore sys.displayhook from __displayhook__,
     # see https://bugs.python.org/issue26092.

--- a/diofant/core/basic.py
+++ b/diofant/core/basic.py
@@ -320,11 +320,11 @@ class Basic(metaclass=ManagedProperties):
 
     def _repr_pretty_(self, p, cycle):
         from diofant.printing import pretty
-        p.text(pretty(self, order=None))
+        p.text(pretty(self))
 
     def _repr_latex_(self):
         from diofant.printing import latex
-        return '$$' + latex(self, order=None) + '$$'
+        return latex(self, mode='equation')
 
     def atoms(self, *types):
         """Returns the atoms that form the current object.

--- a/diofant/interactive/__init__.py
+++ b/diofant/interactive/__init__.py
@@ -1,4 +1,5 @@
 """Helper module for setting up interactive Diofant sessions. """
 
 from .printing import init_printing
-from .session import init_ipython_session
+
+init_printing()

--- a/diofant/interactive/printing.py
+++ b/diofant/interactive/printing.py
@@ -1,11 +1,9 @@
-"""Tools for setting up printing in interactive sessions. """
-
 import builtins
 import os
 import sys
 
-from diofant import latex as default_latex
-from diofant.utilities.misc import debug
+from diofant.printing import latex, sstrrepr, pretty
+from diofant.printing.printer import Printer
 
 
 def _init_python_printing(stringify_func):
@@ -24,204 +22,92 @@ def _init_python_printing(stringify_func):
     sys.displayhook = _displayhook
 
 
-def _init_ipython_printing(ip, stringify_func, use_latex,
-                           print_builtin,
-                           latex_printer):
+def _init_ipython_printing(ip, stringify_func):
     """Setup printing in IPython interactive session. """
 
-    import IPython
-    from diofant.core.basic import Basic
-    from diofant.matrices.matrices import MatrixBase
-
-    latex = latex_printer or default_latex
-
-    def _print_plain(arg, p, cycle):
-        """caller for pretty, for use in IPython"""
-        if _can_print_latex(arg):
-            p.text(stringify_func(arg))
-        else:
-            p.text(IPython.lib.pretty.pretty(arg))
-
-    def _can_print_latex(o):
-        """Return True if type o can be printed with LaTeX.
-
-        If o is a container type, this is True if and only if every element of
-        o can be printed with LaTeX.
-        """
-        if isinstance(o, (list, tuple, set, frozenset)):
-            return all(_can_print_latex(i) for i in o)
-        elif isinstance(o, dict):
-            return all(_can_print_latex(i) and _can_print_latex(o[i]) for i in o)
-        elif isinstance(o, bool):
-            return False
-        # TODO : Investigate if "elif hasattr(o, '_latex')" is more useful
-        # to use here, than these explicit imports.
-        elif isinstance(o, (Basic, MatrixBase)):
-            return True
-        elif isinstance(o, (float, int)) and print_builtin:
-            return True
-        return False
+    def _print_plain_text(arg, p, cycle):
+        p.text(stringify_func(arg))
 
     def _print_latex_text(o):
-        """
-        A function to generate the latex representation of diofant expressions.
-        """
-        if _can_print_latex(o):
-            s = latex(o, mode='plain')
-            s = s.replace(r'\dag', r'\dagger')
-            s = s.strip('$')
-            return '$$%s$$' % s
+        return latex(o, mode='equation')
 
-    printable_types = [Basic, MatrixBase, float, tuple, list, set,
-                       frozenset, dict, int]
+    printable_types = [float, tuple, list, set, frozenset, dict, int]
 
     plaintext_formatter = ip.display_formatter.formatters['text/plain']
+    latex_formatter = ip.display_formatter.formatters['text/latex']
 
     for cls in printable_types:
-        plaintext_formatter.for_type(cls, _print_plain)
+        plaintext_formatter.for_type(cls, _print_plain_text)
 
-    latex_formatter = ip.display_formatter.formatters['text/latex']
-    if use_latex:
-        debug("init_printing: using mathjax formatter")
-        for cls in printable_types:
-            latex_formatter.for_type(cls, _print_latex_text)
-    else:
-        debug("init_printing: not using text/latex formatter")
-        for cls in printable_types:
-            if cls in latex_formatter.type_printers:
-                latex_formatter.type_printers.pop(cls)
+    for cls in printable_types:
+        latex_formatter.for_type(cls, _print_latex_text)
 
 
-def init_printing(pretty_print=True, order=None, use_unicode=None,
-                  use_latex=None, wrap_line=None, num_columns=None,
-                  no_global=False, ip=None,
-                  print_builtin=True,
-                  str_printer=None, pretty_printer=None,
-                  latex_printer=None):
+def init_printing(no_global=False, pretty_print=None, **settings):
     r"""Initializes pretty-printer depending on the environment.
 
     Parameters
     ==========
 
-    pretty_print: boolean
-        If True, use pretty_print to stringify or the provided pretty
-        printer; if False, use sstrrepr to stringify or the provided string
-        printer.
-    order: string or None
-        There are a few different settings for this parameter:
-        lex (default), which is lexographic order;
-        grlex, which is graded lexographic order;
-        grevlex, which is reversed graded lexographic order;
-        None, which sets it to lex.
-    use_unicode: boolean or None
-        If True, use unicode characters;
-        if False, do not use unicode characters.
-    use_latex: string, boolean, or None
-        If True, use default latex rendering in GUI interfaces;
-        if False, do not use latex rendering;
-    wrap_line: boolean
-        If True, lines will wrap at the end; if False, they will not wrap
-        but continue as one line. This is only relevant if `pretty_print` is
-        True.
-    num_columns: int or None
-        If int, number of columns before wrapping is set to num_columns; if
-        None, number of columns before wrapping is set to terminal width.
-        This is only relevant if `pretty_print` is True.
-    no_global: boolean
+    no_global : boolean
         If True, the settings become system wide;
         if False, use just for this console/session.
-    ip: An interactive console
-        This can either be an instance of IPython,
-        or a class that derives from code.InteractiveConsole.
-    print_builtin: boolean, optional, default=True
-        If true then floats and integers will be printed. If false the
-        printer will only print Diofant types.
-    str_printer: function, optional, default=None
-        A custom string printer function. This should mimic
-        diofant.printing.sstrrepr().
-    pretty_printer: function, optional, default=None
-        A custom pretty printer. This should mimic diofant.printing.pretty().
-    latex_printer: function, optional, default=None
-        A custom LaTeX printer. This should mimic diofant.printing.latex()
-        This should mimic diofant.printing.latex().
+    pretty_print : boolean or None
+        Enable pretty printer (turned on by default for IPython, but
+        disabled for plain Python console).
+    \*\*settings : dict
+        A dictionary of default settings for printers.
 
     Examples
     ========
 
     >>> from diofant.interactive import init_printing
     >>> from diofant import Symbol, sqrt
-    >>> from diofant.abc import x, y
+    >>> from diofant.abc import x, y, theta
     >>> sqrt(5)
     sqrt(5)
-    >>> init_printing(pretty_print=True)
+    >>> init_printing(pretty_print=True, no_global=True)
     >>> sqrt(5)
       ___
-    \/ 5
-    >>> theta = Symbol('theta')
-    >>> init_printing(use_unicode=True)
+    ╲╱ 5
     >>> theta
-    \u03b8
-    >>> init_printing(use_unicode=False)
+    θ
+    >>> init_printing(pretty_print=True, use_unicode=False, no_global=True)
     >>> theta
     theta
-    >>> init_printing(order='grevlex')
+    >>> init_printing(pretty_print=True, order='grevlex', no_global=True)
     >>> y + x + y**2 + x**2
      2    2
     x  + y  + x + y
-    >>> init_printing(pretty_print=False, use_unicode=False, order='lex')
-    >>> y + x + y**2 + x**2
-    x**2 + x + y**2 + y
     """
-    from diofant.printing.printer import Printer
 
-    if pretty_print:
-        if pretty_printer is not None:
-            stringify_func = pretty_printer
-        else:
-            from diofant.printing import pretty as stringify_func
+    try:
+        ip = get_ipython()
+    except NameError:
+        ip = None
+
+    # guess unicode support
+    unicode_term = False
+    TERM = os.environ.get('TERM', '')
+    if TERM != '' and not TERM.endswith('linux'):
+        unicode_term = True
+    if settings.get('use_unicode') is None:
+        settings['use_unicode'] = True if unicode_term else False
+
+    if ip:
+        stringify_func = pretty if pretty_print is not False else sstrrepr
     else:
-        if str_printer is not None:
-            stringify_func = str_printer
-        else:
-            from diofant.printing import sstrrepr as stringify_func
+        stringify_func = sstrrepr if not pretty_print else pretty
 
-    # Even if ip is not passed, double check that not in IPython shell
-    in_ipython = False
-    if ip is None:
-        try:
-            ip = get_ipython()
-        except NameError:
-            pass
-        else:
-            in_ipython = (ip is not None)
-    else:
-        in_ipython = True
-
-    if in_ipython:
-        if use_unicode is None:
-            use_unicode = False if os.environ.get('TERM', '').endswith('linux') else True
-        if use_latex is None:
-            use_latex = True
-
-    if not no_global:
-        Printer.set_global_settings(order=order, use_unicode=use_unicode,
-                                    wrap_line=wrap_line,
-                                    num_columns=num_columns)
-    else:
+    if no_global:
         _stringify_func = stringify_func
 
-        if pretty_print:
-            def stringify_func(expr):
-                return _stringify_func(expr, order=order,
-                                       use_unicode=use_unicode,
-                                       wrap_line=wrap_line,
-                                       num_columns=num_columns)
-        else:
-            def stringify_func(expr):
-                return _stringify_func(expr, order=order)
+        def stringify_func(expr):
+            return _stringify_func(expr, **settings)
+    else:
+        Printer.set_global_settings(**settings)
 
-    if in_ipython:
-        _init_ipython_printing(ip, stringify_func, use_latex,
-                               print_builtin, latex_printer)
+    if ip:
+        _init_ipython_printing(ip, stringify_func)
     else:
         _init_python_printing(stringify_func)

--- a/diofant/interactive/session.py
+++ b/diofant/interactive/session.py
@@ -1,5 +1,3 @@
-"""Tools for setting up interactive sessions. """
-
 import ast
 import builtins
 
@@ -31,7 +29,7 @@ class AutomaticSymbols(ast.NodeTransformer):
             self.visit(s)
 
         for v in self.names:
-            if v in self.app.user_ns.keys() or v in builtins.__dir__():
+            if v in self.app.user_ns.keys() or v in dir(builtins):
                 continue
 
             assign = ast.Assign(targets=[ast.Name(id=v, ctx=ast.Store())],
@@ -50,35 +48,3 @@ class AutomaticSymbols(ast.NodeTransformer):
         if isinstance(node.ctx, ast.Load):
             self.names.append(node.id)
         return node
-
-
-def init_ipython_session(auto_symbols=False,
-                         auto_int_to_Integer=False):
-    """Configure new IPython session.
-
-    Parameters
-    ==========
-
-    auto_int_to_Integer : boolean
-        Enable wrapping all integer literals with
-        Integer.  Default is False.
-
-    auto_symbols : boolean
-        Create missing Symbol definitions automatically
-        on first use.  Default is False.
-    """
-    import IPython
-
-    ip = IPython.get_ipython()
-    if not ip:
-        app = IPython.terminal.ipapp.TerminalIPythonApp()
-        app.display_banner = False
-        app.initialize([])
-        ip = app.shell
-
-    if auto_symbols:
-        ip.ast_transformers.append(AutomaticSymbols(ip))
-    if auto_int_to_Integer:
-        ip.ast_transformers.append(IntegerWrapper())
-
-    return ip

--- a/diofant/interactive/session.py
+++ b/diofant/interactive/session.py
@@ -19,17 +19,21 @@ class IntegerWrapper(ast.NodeTransformer):
 
 class AutomaticSymbols(ast.NodeTransformer):
     """Add missing Symbol definitions automatically."""
-    def __init__(self, app):
+    def __init__(self):
         super(AutomaticSymbols, self).__init__()
-        self.app = app
         self.names = []
 
     def visit_Module(self, node):
+        import IPython
+
+        app = IPython.get_ipython()
+        ignored_names = list(app.user_ns.keys()) + dir(builtins)
+
         for s in node.body:
             self.visit(s)
 
         for v in self.names:
-            if v in self.app.user_ns.keys() or v in dir(builtins):
+            if v in ignored_names:
                 continue
 
             assign = ast.Assign(targets=[ast.Name(id=v, ctx=ast.Store())],

--- a/diofant/interactive/tests/test_ipython.py
+++ b/diofant/interactive/tests/test_ipython.py
@@ -5,17 +5,7 @@ import sys
 
 import pytest
 
-from diofant.interactive.session import (init_ipython_session,
-                                         IntegerWrapper)
-from diofant.core import Symbol, Rational, Integer
-from diofant.external import import_module
-
-ipython = import_module("IPython", min_module_version="2.3.0")
-readline = import_module("readline")
-
-if not ipython:
-    # py.test will not execute any tests now
-    disabled = True
+from diofant.interactive.session import IntegerWrapper
 
 
 @pytest.mark.skipif(sys.version_info >= (3, 5),
@@ -41,52 +31,3 @@ def test_IntegerWrapper():
     assert ast.dump(tree_new) == dump3
     tree_new2 = IntegerWrapper().visit(tree_new)
     assert ast.dump(tree_new2) == dump3
-
-
-def test_automatic_symbols():
-    # this implicitly requires readline
-    if not readline:
-        return
-    # NOTE: Because of the way the hook works, you have to use run_cell(code,
-    # True).  This means that the code must have no Out, or it will be printed
-    # during the tests.
-    app = init_ipython_session(auto_symbols=True)
-    app.run_cell("from diofant import *")
-
-    symbol = "verylongsymbolname"
-    assert symbol not in app.user_ns
-    app.run_cell("a = %s" % symbol, True)
-#   assert symbol not in app.user_ns
-    app.run_cell("a = type(%s)" % symbol, True)
-    assert app.user_ns['a'] == Symbol
-    app.run_cell("%s = Symbol('%s')" % (symbol, symbol), True)
-    assert symbol in app.user_ns
-
-    # Check that built-in names aren't overridden
-    app.run_cell("a = all == __builtin__.all", True)
-    assert "all" not in app.user_ns
-    assert app.user_ns['a'] is True
-
-    # Check that diofant names aren't overridden
-    app.run_cell("import diofant")
-    app.run_cell("a = factorial == diofant.factorial", True)
-    assert app.user_ns['a'] is True
-
-
-def test_int_to_Integer():
-    # XXX: Warning, don't test with == here.  0.5 == Rational(1, 2) is True!
-    app = init_ipython_session(auto_int_to_Integer=True)
-    app.run_cell("from diofant import Integer")
-    app.run_cell("a = 1")
-    assert isinstance(app.user_ns['a'], Integer)
-
-    app.run_cell("a = 1/2")
-    assert isinstance(app.user_ns['a'], Rational)
-    app.run_cell("a = 1")
-    assert isinstance(app.user_ns['a'], Integer)
-    app.run_cell("a = int(1)")
-    assert isinstance(app.user_ns['a'], int)
-    app.run_cell("a = (1/\n2)")
-    assert app.user_ns['a'] == Rational(1, 2)
-    # TODO: How can we test that the output of a SyntaxError is the original
-    # input, not the transformed input?

--- a/diofant/interactive/tests/test_ipythonprinting.py
+++ b/diofant/interactive/tests/test_ipythonprinting.py
@@ -46,7 +46,7 @@ def test_automatic_symbols():
     app = init_ipython_session()
     app.run_cell("ip = get_ipython()")
     app.run_cell("from diofant.interactive.session import AutomaticSymbols")
-    app.run_cell("ip.ast_transformers.append(AutomaticSymbols(ip))")
+    app.run_cell("ip.ast_transformers.append(AutomaticSymbols())")
     app.run_cell("from diofant import Symbol, factorial")
 
     symbol = "verylongsymbolname"

--- a/diofant/interactive/tests/test_ipythonprinting.py
+++ b/diofant/interactive/tests/test_ipythonprinting.py
@@ -2,14 +2,74 @@
 
 import pytest
 
-from diofant.interactive.session import init_ipython_session
+from diofant.core import Symbol, Integer, Rational
 from diofant.external import import_module
 
 ipython = import_module("IPython", min_module_version="2.3.0")
 
 
+def init_ipython_session():
+    ip = ipython.get_ipython()
+
+    if not ip:
+        app = ipython.terminal.ipapp.TerminalIPythonApp()
+        app.display_banner = False
+        app.initialize([])
+        ip = app.shell
+
+    return ip
+
+
 @pytest.mark.skipif(ipython is None, reason="no IPython")
-def test_ipythonprinting():
+def test_int_to_Integer():
+    app = init_ipython_session()
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("from diofant import Integer")
+    app.run_cell("from diofant.interactive.session import IntegerWrapper")
+    app.run_cell("ip.ast_transformers.append(IntegerWrapper())")
+
+    app.run_cell("a = 1")
+    assert isinstance(app.user_ns['a'], Integer)
+
+    app.run_cell("a = 1/2")
+    assert isinstance(app.user_ns['a'], Rational)
+    app.run_cell("a = 1")
+    assert isinstance(app.user_ns['a'], Integer)
+    app.run_cell("a = int(1)")
+    assert isinstance(app.user_ns['a'], int)
+    app.run_cell("a = (1/\n2)")
+    assert app.user_ns['a'] == Rational(1, 2)
+
+
+@pytest.mark.skipif(ipython is None, reason="no IPython")
+def test_automatic_symbols():
+    app = init_ipython_session()
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("from diofant.interactive.session import AutomaticSymbols")
+    app.run_cell("ip.ast_transformers.append(AutomaticSymbols(ip))")
+    app.run_cell("from diofant import Symbol, factorial")
+
+    symbol = "verylongsymbolname"
+    assert symbol not in app.user_ns
+    app.run_cell("a = %s" % symbol)
+    app.run_cell("a = type(%s)" % symbol)
+    assert app.user_ns['a'] == Symbol
+    app.run_cell("%s = Symbol('%s')" % (symbol, symbol))
+    assert symbol in app.user_ns
+
+    # Check that built-in names aren't overridden
+    app.run_cell("a = all == __builtin__.all")
+    assert "all" not in app.user_ns
+    assert app.user_ns['a'] is True
+
+    # Check that diofant names aren't overridden
+    app.run_cell("import diofant")
+    app.run_cell("a = factorial == diofant.factorial")
+    assert app.user_ns['a'] is True
+
+
+@pytest.mark.skipif(ipython is None, reason="no IPython")
+def test_printing():
     # Initialize and setup IPython session
     app = init_ipython_session()
     app.run_cell("ip = get_ipython()")
@@ -34,7 +94,21 @@ def test_ipythonprinting():
 
 
 @pytest.mark.skipif(ipython is None, reason="no IPython")
-def test_print_builtin_option():
+def test_dumbterm(monkeypatch):
+    monkeypatch.setenv('TERM', '')
+    app = init_ipython_session()
+    app.run_cell("ip = get_ipython()")
+    app.run_cell("inst = ip.instance()")
+    app.run_cell("format = inst.display_formatter.format")
+    app.run_cell("from diofant import Symbol")
+    app.run_cell("from diofant import init_printing")
+    app.run_cell("init_printing()")
+    app.run_cell("a = format(Symbol('pi'))")
+    assert app.user_ns['a'][0]['text/plain'] == "pi"
+
+
+@pytest.mark.skipif(ipython is None, reason="no IPython")
+def test_print_builtins():
     # Initialize and setup IPython session
     app = init_ipython_session()
     app.run_cell("ip = get_ipython()")
@@ -42,6 +116,9 @@ def test_print_builtin_option():
     app.run_cell("format = inst.display_formatter.format")
     app.run_cell("from diofant import Symbol")
     app.run_cell("from diofant import init_printing, pretty, sstrrepr")
+
+    app.run_cell("a = format(int(1))")
+    pytest.raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
 
     app.run_cell("init_printing()")
     app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")
@@ -54,36 +131,33 @@ def test_print_builtin_option():
 
     # If we enable the default printing, then the dictionary's should render
     # as a LaTeX version of the whole dict: ${\pi: 3.14, n_i: 3}$
-    app.run_cell("init_printing(use_latex=True)")
+    app.run_cell("init_printing()")
     app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = True")
     app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")
     text = app.user_ns['a'][0]['text/plain']
     latex = app.user_ns['a'][0]['text/latex']
     assert text in ('{n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3, \N{GREEK SMALL LETTER PI}: 3.14}',
                     '{\N{GREEK SMALL LETTER PI}: 3.14, n\N{LATIN SUBSCRIPT SMALL LETTER I}: 3}')
-    assert latex == r'$$\left \{ n_{i} : 3, \quad \pi : 3.14\right \}$$'
+    assert latex == r'\begin{equation}\left \{ n_{i} : 3, \quad \pi : 3.14\right \}\end{equation}'
 
     app.run_cell("a = format([Symbol('x'), Symbol('y')])")
     latex = app.user_ns['a'][0]['text/latex']
-    assert latex in (r'$$\left [ x, \quad y\right ]$$',
-                     r'$$\left [ y, \quad x\right ]$$')
+    assert latex in (r'\begin{equation}\left [ x, \quad y\right ]\end{equation}',
+                     r'\begin{equation}left [ y, \quad x\right ]\end{equation}')
 
     app.run_cell("a = format(False)")
     assert app.user_ns['a'][0]['text/plain'] == r'False'
 
-    app.run_cell("init_printing(pretty_printer=pretty, no_global=True)")
-    app.run_cell("a = format(Symbol('pi'))")
-    assert app.user_ns['a'][0]['text/plain'] in '\N{GREEK SMALL LETTER PI}'
+    app.run_cell("init_printing(no_global=True)")
+    app.run_cell("a = format(set([Symbol('pi')]))")
+    assert app.user_ns['a'][0]['text/plain'] == '{\N{GREEK SMALL LETTER PI}}'
 
-    app.run_cell("init_printing(pretty_print=False, str_printer=sstrrepr)")
+    app.run_cell("init_printing(use_unicode=False)")
     app.run_cell("a = format(Symbol('pi'))")
     assert app.user_ns['a'][0]['text/plain'] == 'pi'
 
-    app.run_cell("init_printing(print_builtin=False)")
-    app.run_cell("a = format(int(1))")
-    pytest.raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])
-
-    app.run_cell("init_printing(ip=ip, use_latex=False)")
+    app.run_cell("init_printing()")
+    app.run_cell("inst.display_formatter.formatters['text/latex'].enabled = False")
     app.run_cell("a = format({Symbol('pi'): 3.14, Symbol('n_i'): 3})")
     text = app.user_ns['a'][0]['text/plain']
     pytest.raises(KeyError, lambda: app.user_ns['a'][0]['text/latex'])

--- a/diofant/matrices/matrices.py
+++ b/diofant/matrices/matrices.py
@@ -710,11 +710,11 @@ class MatrixBase(object):
 
     def _repr_pretty_(self, p, cycle):
         from diofant.printing import pretty
-        p.text(pretty(self, order=None))
+        p.text(pretty(self))
 
     def _repr_latex_(self):
         from diofant.printing import latex
-        return '$$' + latex(self, order=None) + '$$'
+        return latex(self, mode='equation')
 
     def cholesky(self):
         """Returns the Cholesky decomposition L of a matrix A

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -40,9 +40,8 @@ Python interpreter and execute some simple statements like the ones below::
     >>> ((1 + x)**(1/x)).limit(x, 0)
     E
 
-However, we recommend using `IPython`_ for working interactively.
-Function :py:func:`~diofant.interactive.session.init_ipython_session`
-could be used to enable custom input transformations, that help reduce
+However, we recommend using `IPython`_ for working interactively.  Use input
+transformations from the module :mod:`diofant.interactive`, that could reduce
 boilerplate while interacting with Diofant due to the Python language syntax.
 
 For a starter guide on using Diofant, refer to the :ref:`tutorial`.

--- a/docs/modules/evalf.rst
+++ b/docs/modules/evalf.rst
@@ -285,7 +285,8 @@ Oscillatory quadrature requires an integrand containing a factor cos(ax+b) or
 sin(ax+b). Note that many other oscillatory integrals can be transformed to
 this form with a change of variables:
 
-    >>> init_printing(use_unicode=False, wrap_line=False, no_global=True)
+    >>> init_printing(pretty_print=True, use_unicode=False,
+    ...               wrap_line=False, no_global=True)
     >>> intgrl = Integral(sin(1/x), (x, 0, 1)).transform(x, 1/x)
     >>> intgrl
      oo

--- a/docs/modules/integrals/integrals.rst
+++ b/docs/modules/integrals/integrals.rst
@@ -15,7 +15,7 @@ Examples
 Diofant can integrate a vast array of functions. It can integrate polynomial functions::
 
     >>> from diofant import *
-    >>> init_printing(use_unicode=False, wrap_line=False, no_global=True)
+    >>> init_printing(pretty_print=True, use_unicode=False, wrap_line=False, no_global=True)
     >>> x = Symbol('x')
     >>> integrate(x**2 + x + 1, x)
      3    2

--- a/docs/modules/interactive.rst
+++ b/docs/modules/interactive.rst
@@ -1,14 +1,10 @@
 Interactive
 ===========
 
-Functions reference
--------------------
+.. automodule:: diofant.interactive
 
-.. autofunction:: diofant.interactive.printing.init_printing
-.. autofunction:: diofant.interactive.session.init_ipython_session
+.. automodule:: diofant.interactive.printing
+    :members:
 
-AST Transformers
-----------------
-
-.. autoclass:: diofant.interactive.session.IntegerWrapper
-.. autoclass:: diofant.interactive.session.AutomaticSymbols
+.. automodule:: diofant.interactive.session
+    :members:

--- a/docs/modules/matrices/matrices.rst
+++ b/docs/modules/matrices/matrices.rst
@@ -10,7 +10,7 @@ The linear algebra module is designed to be as simple as possible. First, we
 import and declare our first ``Matrix`` object:
 
     >>> from diofant.interactive.printing import init_printing
-    >>> init_printing(use_unicode=False, wrap_line=False, no_global=True)
+    >>> init_printing(pretty_print=True, use_unicode=False, wrap_line=False, no_global=True)
     >>> from diofant.matrices import Matrix, eye, zeros, ones, diag, GramSchmidt
     >>> M = Matrix([[1,0,0], [0,0,0]]); M
     [1  0  0]

--- a/docs/modules/polys/agca.rst
+++ b/docs/modules/polys/agca.rst
@@ -52,7 +52,7 @@ All code examples assume::
 
     >>> from diofant import *
     >>> x, y, z = symbols('x,y,z')
-    >>> init_printing(use_unicode=True, wrap_line=False, no_global=True)
+    >>> init_printing(pretty_print=True, use_unicode=True, wrap_line=False, no_global=True)
 
 Reference
 =========

--- a/docs/modules/polys/basics.rst
+++ b/docs/modules/polys/basics.rst
@@ -14,7 +14,7 @@ polynomials within Diofant. All code examples assume::
 
     >>> from diofant import *
     >>> x, y, z = symbols('x,y,z')
-    >>> init_printing(use_unicode=False, wrap_line=False, no_global=True)
+    >>> init_printing(pretty_print=True, use_unicode=False, wrap_line=False, no_global=True)
 
 Basic functionality
 ===================

--- a/docs/modules/polys/wester.rst
+++ b/docs/modules/polys/wester.rst
@@ -22,7 +22,7 @@ computations were done using the following setup::
 
     >>> from diofant import *
 
-    >>> init_printing(use_unicode=True, wrap_line=False, no_global=True)
+    >>> init_printing(pretty_print=True, use_unicode=True, wrap_line=False, no_global=True)
 
     >>> var('x,y,z,s,c,n')
     (x, y, z, s, c, n)

--- a/docs/tutorial/calculus.rst
+++ b/docs/tutorial/calculus.rst
@@ -8,7 +8,7 @@ with the math of any part of this section, you may safely skip it.
 
     >>> from diofant import *
     >>> x, y, z = symbols('x y z')
-    >>> init_printing(use_unicode=True)
+    >>> init_printing(pretty_print=True, use_unicode=True)
 
 .. _tutorial-derivatives:
 

--- a/docs/tutorial/intro.rst
+++ b/docs/tutorial/intro.rst
@@ -118,7 +118,7 @@ of symbolic power Diofant is capable of, to whet your appetite.
 
 This will make all further examples pretty print with unicode characters.
 
- >>> init_printing(use_unicode=True)
+ >>> init_printing(pretty_print=True, use_unicode=True)
 
 Take the derivative of `\sin{(x)}e^x`.
 

--- a/docs/tutorial/matrices.rst
+++ b/docs/tutorial/matrices.rst
@@ -3,7 +3,7 @@
 ==========
 
     >>> from diofant import *
-    >>> init_printing(use_unicode=True)
+    >>> init_printing(pretty_print=True, use_unicode=True)
 
 To make a matrix in Diofant, use the ``Matrix`` object.  A matrix is constructed
 by providing a list of row vectors that make up the matrix.  For example,

--- a/docs/tutorial/simplification.rst
+++ b/docs/tutorial/simplification.rst
@@ -8,7 +8,7 @@ To make this document easier to read, we are going to enable pretty printing.
 
     >>> from diofant import *
     >>> from diofant.abc import x, y, z
-    >>> init_printing(use_unicode=True)
+    >>> init_printing(pretty_print=True, use_unicode=True)
 
 Automatic simplification
 ========================

--- a/docs/tutorial/solvers.rst
+++ b/docs/tutorial/solvers.rst
@@ -4,7 +4,7 @@
 
     >>> from diofant import *
     >>> x, y, z = symbols('x y z')
-    >>> init_printing(use_unicode=True)
+    >>> init_printing(pretty_print=True, use_unicode=True, no_global=True)
 
 A Note about Equations
 ======================


### PR DESCRIPTION
* now run init_printing() on import
* setup here displayhook-related stuff and printing of non-Diofant's  types (e.g. sets)
* sstrrepr now default for Python console, unicode pretty-printing - for IPython
  - [x] ~~shouldn't defaults be same?~~
* drop init_ipython_session(), provide low-level tools (AST transformers)
* simplify AutomaticSymbols signature and tests