### PR TITLE
Fix repr methods of polys module

### DIFF
--- a/diofant/core/function.py
+++ b/diofant/core/function.py
@@ -174,6 +174,12 @@ class FunctionClass(ManagedProperties):
         return FiniteSet(*self._nargs) if self._nargs else S.Naturals0
 
     def __repr__(self):
+        if issubclass(self, AppliedUndef):
+            return 'Function(%r)' % (self.__name__)
+        else:
+            return self.__name__
+
+    def __str__(self):
         return self.__name__
 
 

--- a/diofant/core/function.py
+++ b/diofant/core/function.py
@@ -23,7 +23,7 @@ There are three types of functions implemented in Diofant:
     >>> from diofant.abc import x
     >>> f(x)
     f(x)
-    >>> print(diofant.srepr(f(x).func))
+    >>> print(repr(f(x).func))
     Function('f')
     >>> f(x).args
     (x,)

--- a/diofant/core/symbol.py
+++ b/diofant/core/symbol.py
@@ -78,7 +78,7 @@ class BaseSymbol(AtomicExpr, Boolean):
         obj.name = name
 
         # TODO: Issue sympy/sympy#8873: Forcing the commutative assumption here means
-        # later code such as ``srepr()`` cannot tell whether the user
+        # later code such as ``repr()`` cannot tell whether the user
         # specified ``commutative=True`` or omitted it.  To workaround this,
         # we keep a copy of the assumptions dict, then create the StdFactKB,
         # and finally overwrite its ``._generator`` with the dict copy.  This

--- a/diofant/core/tests/test_sympify.py
+++ b/diofant/core/tests/test_sympify.py
@@ -5,7 +5,7 @@ import mpmath
 import pytest
 
 from diofant import (Symbol, exp, Integer, Float, sin, cos, Poly, Lambda,
-                     Function, I, S, sqrt, srepr, Rational, Tuple, Matrix,
+                     Function, I, S, sqrt, Rational, Tuple, Matrix,
                      Interval, Add, Mul, Pow, Or, true, false, Abs, pi, Xor)
 from diofant.core.sympify import sympify, _sympify, SympifyError
 from diofant.core.decorators import _sympifyit
@@ -398,7 +398,7 @@ def test_S_sympify():
 
 
 def test_sympyissue_4788():
-    assert srepr(sympify(1.0 + 0J)) == srepr(Float(1.0)) == srepr(Float(1.0))
+    assert repr(sympify(1.0 + 0J)) == repr(Float(1.0)) == repr(Float(1.0))
 
 
 def test_sympyissue_4798_None():

--- a/diofant/functions/elementary/tests/test_piecewise.py
+++ b/diofant/functions/elementary/tests/test_piecewise.py
@@ -4,7 +4,6 @@ from diofant import (adjoint, And, Basic, conjugate, diff, expand, Eq, Function,
                      I, Integral, integrate, Interval, lambdify, log, Max, Min,
                      oo, Or, pi, Piecewise, piecewise_fold, Rational, solve,
                      symbols, transpose, cos, exp, Abs, Not, Symbol, sympify, Gt)
-from diofant.printing import srepr
 
 x, y = symbols('x y')
 z = symbols('z', nonzero=True)
@@ -492,9 +491,9 @@ def test_as_expr_set_pairs():
          (0, Interval(-oo, 0, True, True))]
 
 
-def test_S_srepr_is_identity():
+def test_S_repr_is_identity():
     p = Piecewise((10, Eq(x, 0)), (12, True))
-    q = sympify(srepr(p))
+    q = sympify(repr(p))
     assert p == q
 
 

--- a/diofant/matrices/matrices.py
+++ b/diofant/matrices/matrices.py
@@ -19,6 +19,7 @@ from diofant.simplify import simplify as _simplify, signsimp, nsimplify
 from diofant.utilities.iterables import flatten
 from diofant.functions.elementary.miscellaneous import sqrt, Max, Min
 from diofant.functions import exp, factorial
+from diofant.printing.defaults import DefaultPrinting
 from diofant.printing import sstr
 
 
@@ -73,7 +74,7 @@ class DeferredVector(Symbol, NotIterable):
         return "DeferredVector('%s')" % (self.name)
 
 
-class MatrixBase:
+class MatrixBase(DefaultPrinting):
 
     # Added just for numpy compatibility
     __array_priority__ = 11
@@ -697,16 +698,6 @@ class MatrixBase:
         if self.rows == 1:
             return "Matrix([%s])" % self.table(printer, rowsep=',\n')
         return "Matrix([\n%s])" % self.table(printer, rowsep=',\n')
-
-    # Note, we always use the default ordering (lex) in __str__ and __repr__,
-    # regardless of the global setting.  See issue sympy/sympy#5487.
-    def __repr__(self):
-        from diofant.printing import srepr
-        return srepr(self, order=None)
-
-    def __str__(self):
-        from diofant.printing import sstr
-        return sstr(self, order=None)
 
     def _repr_pretty_(self, p, cycle):
         from diofant.printing import pretty

--- a/diofant/plotting/experimental_lambdify.py
+++ b/diofant/plotting/experimental_lambdify.py
@@ -44,19 +44,19 @@ from diofant.utilities.iterables import numbered_symbols
 # A: Because it is more complicated and not much more powerful in this case.
 
 # Q: What if I have Symbol('sin') or g=Function('f')?
-# A: You will break the algorithm. We should use srepr to defend against this?
+# A: You will break the algorithm. We should use repr to defend against this?
 #  The problem with Symbol('sin') is that it will be printed as 'sin'. The
 # parser will distinguish it from the function 'sin' because functions are
 # detected thanks to the opening parenthesis, but the lambda expression won't
 # understand the difference if we have also the sin function.
-# The solution (complicated) is to use srepr and maybe ast.
+# The solution (complicated) is to use repr and maybe ast.
 #  The problem with the g=Function('f') is that it will be printed as 'f' but in
 # the global namespace we have only 'g'. But as the same printer is used in the
 # constructor of the namespace there will be no problem.
 
 # Q: What if some of the printers are not printing as expected?
-# A: The algorithm wont work. You must use srepr for those cases. But even
-# srepr may not print well. All problems with printers should be considered
+# A: The algorithm wont work. You must use repr for those cases. But even
+# repr may not print well. All problems with printers should be considered
 # bugs.
 
 # Q: What about _imp_ functions?
@@ -64,7 +64,7 @@ from diofant.utilities.iterables import numbered_symbols
 # faster but it's not worth the code complexity.
 
 # Q: Will ast fix all possible problems?
-# A: No. You will always have to use some printer. Even srepr may not work in
+# A: No. You will always have to use some printer. Even repr may not work in
 # some cases. But if the printer does not work, that should be considered a
 # bug.
 

--- a/diofant/polys/domains/domain.py
+++ b/diofant/polys/domains/domain.py
@@ -50,9 +50,6 @@ class Domain:
     def __str__(self):
         return self.rep
 
-    def __repr__(self):
-        return str(self)
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.dtype))
 

--- a/diofant/polys/domains/domain.py
+++ b/diofant/polys/domains/domain.py
@@ -7,10 +7,11 @@ from diofant.polys.polyerrors import UnificationFailed, CoercionFailed, DomainEr
 from diofant.polys.orderings import lex
 from diofant.polys.polyutils import _unify_gens
 from diofant.utilities import default_sort_key, public
+from diofant.printing.defaults import DefaultPrinting
 
 
 @public
-class Domain:
+class Domain(DefaultPrinting):
     """Represents an abstract domain. """
 
     dtype = None

--- a/diofant/polys/domains/expressiondomain.py
+++ b/diofant/polys/domains/expressiondomain.py
@@ -22,9 +22,6 @@ class ExpressionDomain(Field, CharacteristicZero, SimpleDomain):
             else:
                 self.ex = ex.ex
 
-        def __repr__(self):
-            return 'EX(%s)' % repr(self.ex)
-
         def __str__(self):
             return 'EX(%s)' % str(self.ex)
 

--- a/diofant/polys/domains/modularinteger.py
+++ b/diofant/polys/domains/modularinteger.py
@@ -25,9 +25,6 @@ class ModularInteger(DomainElement):
     def __hash__(self):
         return hash((self.val, self.mod))
 
-    def __repr__(self):
-        return "%s(%s)" % (self.__class__.__name__, self.val)
-
     def __str__(self):
         return "%s mod %s" % (self.val, self.mod)
 

--- a/diofant/polys/domains/mpelements.py
+++ b/diofant/polys/domains/mpelements.py
@@ -106,7 +106,7 @@ class MPContext(PythonMPContext):
         raise ValueError("expected a real number, got %s" % tol)
 
     def _convert_fallback(self, x, strings):
-        raise TypeError("cannot create mpf from " + repr(x))
+        raise TypeError("cannot create mpf from " + str(x))
 
     @property
     def _repr_digits(self):

--- a/diofant/polys/orderings.py
+++ b/diofant/polys/orderings.py
@@ -2,6 +2,7 @@
 
 __all__ = ("lex", "grlex", "grevlex", "ilex", "igrlex", "igrevlex")
 
+from diofant.core.containers import Tuple
 from diofant.core.symbol import Symbol
 from diofant.core.compatibility import iterable
 
@@ -12,12 +13,6 @@ class MonomialOrder:
     alias = None
     is_global = None
     is_default = False
-
-    def __repr__(self):
-        if self.alias:
-            return str(self)
-        else:
-            return self.__class__.__name__ + "()"
 
     def __str__(self):
         return self.alias
@@ -115,12 +110,7 @@ class ProductOrder(MonomialOrder):
     def __call__(self, monomial):
         return tuple(O(lamda(monomial)) for (O, lamda) in self.args)
 
-    def __repr__(self):
-        from diofant.core import Tuple
-        return self.__class__.__name__ + repr(Tuple(*[x[0] for x in self.args]))
-
     def __str__(self):
-        from diofant.core import Tuple
         return self.__class__.__name__ + str(Tuple(*[x[0] for x in self.args]))
 
     def __eq__(self, other):

--- a/diofant/polys/polyclasses.py
+++ b/diofant/polys/polyclasses.py
@@ -120,10 +120,6 @@ class DMP(CantSympify):
         self.domain = dom
         self.ring = ring
 
-    def __repr__(self):
-        return "%s(%s, %s, %s)" % (self.__class__.__name__, self.rep,
-                                   self.domain, self.ring)
-
     def __hash__(self):
         return hash((self.__class__.__name__, self.to_tuple(),
                      self.lev, self.domain, self.ring))
@@ -1074,10 +1070,6 @@ class DMF(CantSympify):
 
         return num, den, lev
 
-    def __repr__(self):
-        return "%s((%s, %s), %s, %s)" % (self.__class__.__name__, self.num,
-                                         self.den, self.domain, self.ring)
-
     def __hash__(self):
         return hash((self.__class__.__name__, dmp_to_tuple(self.num, self.lev),
                      dmp_to_tuple(self.den, self.lev), self.lev, self.domain,
@@ -1470,10 +1462,6 @@ class ANP(CantSympify):
                 self.mod = dup_strip(mod)
 
         self.domain = dom
-
-    def __repr__(self):
-        return "%s(%s, %s, %s)" % (self.__class__.__name__, self.rep,
-                                   self.mod, self.domain)
 
     def __hash__(self):
         return hash((self.__class__.__name__, self.to_tuple(),

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -1745,9 +1745,6 @@ class RealInterval:
         """Return tuple representation of real isolating interval. """
         return self.a, self.b
 
-    def __repr__(self):
-        return "(%s, %s)" % (self.a, self.b)
-
     def is_disjoint(self, other):
         """Return ``True`` if two isolation intervals are disjoint. """
         return (self.b <= other.a or other.b <= self.a)
@@ -1851,9 +1848,6 @@ class ComplexInterval:
     def as_tuple(self):
         """Return tuple representation of complex isolating interval. """
         return (self.ax, self.ay), (self.bx, self.by)
-
-    def __repr__(self):
-        return "(%s, %s) x (%s, %s)" % (self.ax, self.bx, self.ay, self.by)
 
     def conjugate(self):
         """This complex interval really is located in lower half-plane. """

--- a/diofant/printing/defaults.py
+++ b/diofant/printing/defaults.py
@@ -15,4 +15,6 @@ class DefaultPrinting:
         from diofant.printing.str import sstr
         return sstr(self, order=None)
 
-    __repr__ = __str__
+    def __repr__(self):
+        from diofant.printing import srepr
+        return srepr(self, order=None)

--- a/diofant/printing/repr.py
+++ b/diofant/printing/repr.py
@@ -172,6 +172,18 @@ class ReprPrinter(Printer):
         return "%s(%s, %s, %s)" % (ring.__class__.__name__,
             self._print(ring.symbols), self._print(ring.domain), self._print(ring.order))
 
+    def _print_GMPYIntegerRing(self, expr):
+        return "%s()" % expr.__class__.__name__
+    _print_GMPYRationalField = _print_GMPYIntegerRing
+    _print_PythonIntegerRing = _print_GMPYIntegerRing
+    _print_PythonRationalField = _print_GMPYIntegerRing
+
+    _print_LexOrder = _print_GMPYIntegerRing
+    _print_GradedLexOrder = _print_LexOrder
+
+    def _print_PolynomialRing(self, expr):
+        return "%s(%s)" % (expr.__class__.__name__, repr(expr.ring))
+
     def _print_FracField(self, field):
         return "%s(%s, %s, %s)" % (field.__class__.__name__,
             self._print(field.symbols), self._print(field.domain), self._print(field.order))

--- a/diofant/printing/repr.py
+++ b/diofant/printing/repr.py
@@ -1,7 +1,8 @@
 """
 A Printer for generating executable code.
 
-The most important function here is srepr that returns a string so that the
+The most important function here is srepr (that is an exact equivalent of
+builtin repr, except for optional arguments) that returns a string so that the
 relation eval(srepr(expr))=expr holds in an appropriate environment.
 """
 

--- a/diofant/printing/tests/test_dot.py
+++ b/diofant/printing/tests/test_dot.py
@@ -1,6 +1,6 @@
 from diofant.printing.dot import (styleof, attrprint, dotnode,
                                   dotedges, dotprint)
-from diofant import Symbol, Integer, Basic, Expr, srepr
+from diofant import Symbol, Integer, Basic, Expr
 from diofant.abc import x
 
 
@@ -70,6 +70,6 @@ def test_Matrix_and_non_basics():
 
 
 def test_labelfunc():
-    text = dotprint(x + 2, labelfunc=srepr)
+    text = dotprint(x + 2, labelfunc=repr)
     assert "Symbol('x')" in text
     assert "Integer(2)" in text

--- a/diofant/printing/tests/test_repr.py
+++ b/diofant/printing/tests/test_repr.py
@@ -4,12 +4,12 @@ from diofant import (symbols, Function, Integer, Matrix, Abs, Rational, Float,
                      S, WildFunction, ImmutableMatrix, sin, true, false, ones,
                      Symbol, Dummy, Wild, AlgebraicNumber, sqrt, root)
 from diofant.geometry import Point, Ellipse
-from diofant.printing import srepr
+from diofant.printing.repr import srepr
 from diofant.polys import ring, field, ZZ, QQ, lex, grlex
 
 x, y = symbols('x,y')
 
-# eval(srepr(expr)) == expr has to succeed in the right environment. The right
+# eval(repr(expr)) == expr has to succeed in the right environment. The right
 # environment is the scope of "from diofant import *" for most cases.
 ENV = {}
 imports = """
@@ -23,12 +23,12 @@ exec(imports, ENV)
 
 def sT(expr, string):
     """
-    sT := sreprTest
+    sT := reprTest
 
-    Tests that srepr delivers the expected string and that
-    the condition eval(srepr(expr))==expr holds.
+    Tests that repr delivers the expected string and that
+    the condition eval(repr(expr))==expr holds.
     """
-    assert srepr(expr) == string
+    assert repr(expr) == string
     assert eval(string, ENV) == expr
 
 
@@ -36,12 +36,13 @@ def test_printmethod():
     class R(Abs):
         def _diofantrepr(self, printer):
             return "foo(%s)" % printer._print(self.args[0])
-    assert srepr(R(x)) == "foo(Symbol('x'))"
+    assert repr(R(x)) == "foo(Symbol('x'))"
 
 
 def test_Add():
     sT(x + y, "Add(Symbol('x'), Symbol('y'))")
-    assert srepr(x**2 + 1, order='lex') == "Add(Pow(Symbol('x'), Integer(2)), Integer(1))"
+    assert srepr(x**2 + 1, order='lex') == ("Add(Pow(Symbol('x'), "
+                                            "Integer(2)), Integer(1))")
 
 
 def test_Function():
@@ -135,8 +136,8 @@ def test_Symbol_two_assumptions():
     # order could vary
     s1 = "Symbol('x', integer=True, negative=False)"
     s2 = "Symbol('x', negative=False, integer=True)"
-    assert srepr(x) in (s1, s2)
-    assert eval(srepr(x), ENV) == x
+    assert repr(x) in (s1, s2)
+    assert eval(repr(x), ENV) == x
 
 
 def test_Symbol_no_special_commutative_treatment():
@@ -154,14 +155,14 @@ def test_Wild():
 def test_Dummy():
     # cannot use sT here
     d = Dummy('d', nonzero=True)
-    assert srepr(d) == "Dummy('d', nonzero=True)"
+    assert repr(d) == "Dummy('d', nonzero=True)"
 
 
 def test_Dummy_from_Symbol():
     # should not get the full dictionary of assumptions
     n = Symbol('n', integer=True)
     d = n.as_dummy()
-    assert srepr(d) == "Dummy('n', integer=True)"
+    assert repr(d) == "Dummy('n', integer=True)"
 
 
 def test_tuple():
@@ -173,7 +174,7 @@ def test_WildFunction():
     sT(WildFunction('w'), "WildFunction('w')")
 
 
-def test_settins():
+def test_settings():
     pytest.raises(TypeError, lambda: srepr(x, method="garbage"))
 
 
@@ -227,5 +228,5 @@ def test_FracElement():
 
 
 def test_BooleanAtom():
-    assert srepr(true) == "true"
-    assert srepr(false) == "false"
+    assert repr(true) == "true"
+    assert repr(false) == "false"

--- a/diofant/printing/tests/test_repr.py
+++ b/diofant/printing/tests/test_repr.py
@@ -12,7 +12,13 @@ x, y = symbols('x,y')
 # eval(srepr(expr)) == expr has to succeed in the right environment. The right
 # environment is the scope of "from diofant import *" for most cases.
 ENV = {}
-exec("from diofant import *", ENV)
+imports = """
+from diofant import *
+from diofant.polys.rings import PolyRing
+from diofant.polys.fields import FracField
+from diofant.polys.orderings import LexOrder, GradedLexOrder
+"""
+exec(imports, ENV)
 
 
 def sT(expr, string):
@@ -176,35 +182,48 @@ def test_Mul():
 
 
 def test_PolyRing():
-    assert srepr(ring("x", ZZ, lex)[0]) == "PolyRing((Symbol('x'),), ZZ, lex)"
-    assert srepr(ring("x,y", QQ, grlex)[0]) == "PolyRing((Symbol('x'), Symbol('y')), QQ, grlex)"
-    assert srepr(ring("x,y,z", ZZ["t"], lex)[0]) == "PolyRing((Symbol('x'), Symbol('y'), Symbol('z')), ZZ[t], lex)"
+    sT(ring("x", ZZ, lex)[0], "PolyRing((Symbol('x'),), "
+                              "%s, LexOrder())" % repr(ZZ))
+    sT(ring("x,y", QQ, grlex)[0], "PolyRing((Symbol('x'), Symbol('y')), "
+                                  "%s, GradedLexOrder())" % repr(QQ))
+    sT(ring("x,y,z", ZZ["t"], lex)[0],
+            "PolyRing((Symbol('x'), Symbol('y'), Symbol('z')), "
+            "PolynomialRing(PolyRing((Symbol('t'),), "
+            "%s, LexOrder())), LexOrder())" % repr(ZZ))
 
 
 def test_FracField():
-    assert srepr(field("x", ZZ, lex)[0]) == "FracField((Symbol('x'),), ZZ, lex)"
-    assert srepr(field("x,y", QQ, grlex)[0]) == "FracField((Symbol('x'), Symbol('y')), QQ, grlex)"
-    assert srepr(field("x,y,z", ZZ["t"], lex)[0]) == "FracField((Symbol('x'), Symbol('y'), Symbol('z')), ZZ[t], lex)"
+    sT(field("x", ZZ, lex)[0], "FracField((Symbol('x'),), "
+                               "%s, LexOrder())" % repr(ZZ))
+    sT(field("x,y", QQ, grlex)[0], "FracField((Symbol('x'), Symbol('y')), "
+                                   "%s, GradedLexOrder())" % repr(QQ))
+    sT(field("x,y,z", ZZ["t"], lex)[0],
+            "FracField((Symbol('x'), Symbol('y'), Symbol('z')), "
+            "PolynomialRing(PolyRing((Symbol('t'),), %s, "
+            "LexOrder())), LexOrder())" % repr(ZZ))
 
 
 def test_PolyElement():
     R, x, y = ring("x,y", ZZ)
     g = R.domain.dtype
-    assert srepr(3*x**2*y + 1) == ("PolyElement(PolyRing((Symbol('x'), "
-                                   "Symbol('y')), ZZ, lex), [((2, 1), %s), "
-                                   "((0, 0), %s)])" % (repr(g(3)), repr(g(1))))
+    assert repr(3*x**2*y + 1) == ("PolyElement(PolyRing((Symbol('x'), "
+                                  "Symbol('y')), %s, LexOrder()), [((2, 1), "
+                                  "%s), ((0, 0), %s)])" % (repr(ZZ),
+                                                           repr(g(3)),
+                                                           repr(g(1))))
 
 
 def test_FracElement():
     F, x, y = field("x,y", ZZ)
     g = F.domain.dtype
-    assert srepr((3*x**2*y + 1)/(x - y**2)) == ("FracElement(FracField((Symbol('x'), "
-                                                "Symbol('y')), ZZ, lex), [((2, 1), %s), "
-                                                "((0, 0), %s)], [((1, 0), %s), "
-                                                "((0, 2), %s)])" % (repr(g(3)),
-                                                                    repr(g(1)),
-                                                                    repr(g(1)),
-                                                                    repr(g(-1))))
+    assert repr((3*x**2*y + 1)/(x - y**2)) == ("FracElement(FracField((Symbol('x'), "
+                                               "Symbol('y')), %s, LexOrder()), [((2, 1), %s), "
+                                               "((0, 0), %s)], [((1, 0), %s), "
+                                               "((0, 2), %s)])" % (repr(ZZ),
+                                                                   repr(g(3)),
+                                                                   repr(g(1)),
+                                                                   repr(g(1)),
+                                                                   repr(g(-1))))
 
 
 def test_BooleanAtom():


### PR DESCRIPTION
Keep invariant eval(repr(foo)) == foo.

- [x] ~~use DefaultPrinting for Basic?~~
- [x] cleanup and rebase
