### PR TITLE
Canonicalization of RootOf for algebraic coefficients

### DIFF
--- a/diofant/polys/polyoptions.py
+++ b/diofant/polys/polyoptions.py
@@ -385,7 +385,7 @@ class Composite(BooleanOption, metaclass=OptionType):
         return
 
     requires = []
-    excludes = ['domain', 'split', 'gaussian', 'extension', 'modulus', 'symmetric']
+    excludes = ['domain', 'split', 'gaussian', 'modulus', 'symmetric']
 
 
 class Domain(Option, metaclass=OptionType):

--- a/diofant/polys/polyroots.py
+++ b/diofant/polys/polyroots.py
@@ -680,7 +680,7 @@ def _integer_basis(poly):
             return div
 
 
-def preprocess_roots(poly):
+def preprocess_roots(poly, extension=None):
     """Try to get rid of symbolic coefficients from ``poly``. """
     coeff = S.One
 
@@ -690,7 +690,7 @@ def preprocess_roots(poly):
         return coeff, poly
 
     poly = poly.primitive()[1]
-    poly = poly.retract()
+    poly = poly.retract(extension=extension)
 
     # TODO: This is fragile. Figure out how to make this independent of construct_domain().
     if poly.domain.is_Poly and all(c.is_term for c in poly.rep.coeffs()):

--- a/diofant/polys/polytools.py
+++ b/diofant/polys/polytools.py
@@ -659,7 +659,7 @@ class Poly(Expr):
 
         return self.per(result)
 
-    def retract(self, field=None):
+    def retract(self, field=None, extension=None):
         """
         Recalculate the ground domain of a polynomial.
 
@@ -679,7 +679,7 @@ class Poly(Expr):
         Poly(x**2 + 1, x, domain='QQ')
         """
         dom, rep = construct_domain(self.as_dict(zero=True),
-                                    field=field,
+                                    field=field, extension=extension,
                                     composite=self.domain.is_Composite or None)
         return self.from_dict(rep, self.gens, domain=dom)
 

--- a/diofant/polys/rootoftools.py
+++ b/diofant/polys/rootoftools.py
@@ -35,7 +35,38 @@ _complexes_cache = {}
 
 @public
 class RootOf(Expr):
-    """Represents ``k``-th root of a univariate polynomial. """
+    """
+    Represents ``k``-th root of a univariate polynomial.
+
+    Parameters
+    ==========
+
+    f : Expr
+        Univariate polynomial expression.
+    x : Symbol or Integer
+        Polynomial variable or the index of the root.
+    index : Integer or None, optional
+        Index of the root.  If None (default), parameter ``x`` is
+        used instead as index.
+    radicals : bool, optional
+        Explicitly solve linear or quadratic polynomial
+        equation (enabled by default).
+    expand : bool, optional
+        Expand polynomial, enabled default.
+    evaluate : bool or None, optional
+        Control automatic evaluation.
+    extension : bool or None, optional
+        If enabled, reduce input polynomial to have integer
+        coefficients.
+
+    Examples
+    ========
+
+    >>> from diofant import I
+    >>> from diofant.abc import x
+    >>> RootOf(x**3 + I*x + 2, 0, extension=True)
+    RootOf(x**6 + 4*x**3 + x**2 + 4, 1)
+    """
 
     is_commutative = True
 

--- a/diofant/polys/rootoftools.py
+++ b/diofant/polys/rootoftools.py
@@ -40,7 +40,7 @@ class RootOf(Expr):
     is_commutative = True
 
     def __new__(cls, f, x, index=None, radicals=True, expand=True,
-                evaluate=None):
+                evaluate=None, extension=None):
         """Construct a new ``RootOf`` object for ``k``-th root of ``f``. """
         x = sympify(x)
 
@@ -54,7 +54,7 @@ class RootOf(Expr):
         else:
             raise ValueError("expected an integer root index, got %s" % index)
 
-        poly = PurePoly(f, x, expand=expand)
+        poly = PurePoly(f, x, expand=expand, extension=extension)
 
         if not poly.is_univariate:
             raise PolynomialError("only univariate polynomials are allowed")
@@ -93,7 +93,7 @@ class RootOf(Expr):
         if roots is not None:
             return roots[index]
 
-        coeff, poly = preprocess_roots(poly)
+        coeff, poly = preprocess_roots(poly, extension=extension)
         dom = poly.domain
 
         if dom.is_ZZ:
@@ -167,14 +167,14 @@ class RootOf(Expr):
         return not self.free_symbols
 
     @classmethod
-    def real_roots(cls, poly, radicals=True):
+    def real_roots(cls, poly, radicals=True, extension=None):
         """Get real roots of a polynomial. """
-        return cls._get_roots("_real_roots", poly, radicals)
+        return cls._get_roots("_real_roots", poly, radicals, extension=extension)
 
     @classmethod
-    def all_roots(cls, poly, radicals=True):
+    def all_roots(cls, poly, radicals=True, extension=None):
         """Get real and complex roots of a polynomial. """
-        return cls._get_roots("_all_roots", poly, radicals)
+        return cls._get_roots("_all_roots", poly, radicals, extension=extension)
 
     @classmethod
     def _get_reals_sqf(cls, factor):
@@ -513,14 +513,14 @@ class RootOf(Expr):
                 return [r*_ for _ in cls._roots_trivial(poly, radicals)]
 
     @classmethod
-    def _preprocess_roots(cls, poly):
+    def _preprocess_roots(cls, poly, extension):
         """Take heroic measures to make ``poly`` compatible with ``RootOf``. """
         dom = poly.domain
 
         if not dom.is_Exact:
             poly = poly.to_exact()
 
-        coeff, poly = preprocess_roots(poly)
+        coeff, poly = preprocess_roots(poly, extension=extension)
         dom = poly.domain
 
         if not dom.is_ZZ and poly.LC().is_nonzero is False:
@@ -540,10 +540,10 @@ class RootOf(Expr):
             return cls._new(poly, index)
 
     @classmethod
-    def _get_roots(cls, method, poly, radicals):
+    def _get_roots(cls, method, poly, radicals, extension):
         """Return postprocessed roots of specified kind. """
 
-        coeff, poly = cls._preprocess_roots(poly)
+        coeff, poly = cls._preprocess_roots(poly, extension=extension)
         roots = []
 
         for root in getattr(cls, method)(poly):

--- a/diofant/polys/tests/test_rootoftools.py
+++ b/diofant/polys/tests/test_rootoftools.py
@@ -488,3 +488,20 @@ def test_rewrite():
     assert r4.n() == r4.rewrite(Pow).n()
     r11 = RootOf(x**11 + x - 3, 0)
     assert r11.rewrite(Pow) == r11
+
+
+@pytest.mark.slow
+def test_RootOf_algebraic_domain():
+    e = RootOf(x**4 + sqrt(2)*x**3 - I*x + 1, 0, extension=True)
+    assert e == RootOf(x**16 - 4*x**14 + 8*x**12 - 6*x**10 +
+                       10*x**8 + 5*x**4 + 2*x**2 + 1, 1)
+
+    t = RootOf(x**5 + 4*x + 2, 0)
+    e = RootOf(x**4 + t*x + 1, 1, extension=True)
+    assert e == RootOf(x**20 + 5*x**16 + 10*x**12 + 14*x**8 -
+                       2*x**5 + 9*x**4 + 1, 5)
+
+    e = RootOf(x**3 - root(2, 3)*x + 5*root(-2, 3)**5, 0, extension=True)
+    assert e == RootOf(x**18 + 60*x**13 - 4*x**12 - 8000*x**9 +
+                       3600*x**8 - 120*x**7 + 4*x**6 -
+                       240000*x**4 + 16000*x**3 + 16000000, 1)

--- a/diofant/polys/tests/test_rootoftools.py
+++ b/diofant/polys/tests/test_rootoftools.py
@@ -492,6 +492,9 @@ def test_rewrite():
 
 @pytest.mark.slow
 def test_RootOf_algebraic_domain():
+    assert RootOf(x**3 + I*x + 2, 0,
+                  extension=True) == RootOf(x**6 + 4*x**3 + x**2 + 4, 1)
+
     e = RootOf(x**4 + sqrt(2)*x**3 - I*x + 1, 0, extension=True)
     assert e == RootOf(x**16 - 4*x**14 + 8*x**12 - 6*x**10 +
                        10*x**8 + 5*x**4 + 2*x**2 + 1, 1)

--- a/docs/release/notes-0.9.rst
+++ b/docs/release/notes-0.9.rst
@@ -16,6 +16,7 @@ Major changes
 * Assumptions (old) moved from :class:`~diofant.core.basic.Basic` to :class:`~diofant.core.expr.Expr`, see :pull:`311`.
 * :func:`~diofant.solvers.solvers.solve` now return :class:`list` of :class:`dict`'s, see :pull:`473`.
 * ``diofant.polys.domains`` module is now top-level module :mod:`~diofant.domains`, see :pull:`487`.
+* Support canonicalization of :class:`~diofant.polys.rootoftools.RootOf` instances, construct polynomial with integer coefficients, see :pull:`430`.
 
 Compatibility breaks
 ====================
@@ -193,3 +194,4 @@ These Sympy issues also were addressed:
 * :issue:`369` Issue labeling policy
 * :sympyissue:`13853` Why does the expansion of polylog(1, z) have exp_polar(-I*pi)?
 * :sympyissue:`13849` solve/nonlinsolve: RuntimeError: run out of coefficient configurations
+* :sympyissue:`9366` rootof: Constructing RootOfs with polys containing RootOf coefficients


### PR DESCRIPTION
- [x] rebase and cleanup
- [x] non-sqf resultants
- [x] non-sqf polys
- [x] ~~references~~, proof of the algorithm
- [x] extend docstring to document canonicalization
- [x] should we do this in the constructor, like [Mathematica](http://reference.wolfram.com/language/ref/Root.html)?
- [x] class methods, like all_roots()
- [x] ~~slow tests~~
- [x] extension & composite options compatibility
- [x] ~~fix roots(), see sympy/sympy#7724~~
- [x] release notes

See also
-------------------
- Maple's [RootOf](http://www.maplesoft.com/support/help/Maple/view.aspx?path=RootOf)
- sympy/sympy#9366
- sympy/sympy#8770
  