### PR TITLE
[wip] dsolve: keep Integrals unevaluated by default

### DIFF
--- a/diofant/solvers/ode.py
+++ b/diofant/solvers/ode.py
@@ -268,6 +268,18 @@ from .solvers import solve
 #: ``best``, and ``all_Integral`` meta-hints should not be included in this
 #: list, but ``_best`` and ``_Integral`` hints should be included.
 allhints = (
+    "separable_Integral",
+    "1st_exact_Integral",
+    "1st_linear_Integral",
+    "Bernoulli_Integral",
+    "1st_homogeneous_coeff_subs_indep_div_dep_Integral",
+    "1st_homogeneous_coeff_subs_dep_div_indep_Integral",
+    "almost_linear_Integral",
+    "linear_coefficients_Integral",
+    "separable_reduced_Integral",
+    "nth_linear_constant_coeff_variation_of_parameters_Integral",
+    "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters_Integral",
+    "Liouville_Integral",
     "separable",
     "1st_exact",
     "1st_linear",
@@ -290,18 +302,6 @@ allhints = (
     "Liouville",
     "2nd_power_series_ordinary",
     "2nd_power_series_regular",
-    "separable_Integral",
-    "1st_exact_Integral",
-    "1st_linear_Integral",
-    "Bernoulli_Integral",
-    "1st_homogeneous_coeff_subs_indep_div_dep_Integral",
-    "1st_homogeneous_coeff_subs_dep_div_indep_Integral",
-    "almost_linear_Integral",
-    "linear_coefficients_Integral",
-    "separable_reduced_Integral",
-    "nth_linear_constant_coeff_variation_of_parameters_Integral",
-    "nth_linear_euler_eq_nonhomogeneous_variation_of_parameters_Integral",
-    "Liouville_Integral",
 )
 
 lie_heuristics = (

--- a/diofant/solvers/tests/test_ode.py
+++ b/diofant/solvers/tests/test_ode.py
@@ -4,7 +4,7 @@ from diofant import (Abs, Derivative, Dummy, E, Ei, Eq, Function, I, Integer,
                      Integral, LambertW, Mul, O, Piecewise, Poly, Pow,
                      Rational, RootOf, Subs, Symbol, acos, acosh, asin, asinh,
                      atan, cbrt, cos, diff, dsolve, erf, erfi, exp, log, pi,
-                     root, simplify, sin, sinh, sqrt, sstr, symbols, tan)
+                     root, sec, simplify, sin, sinh, sqrt, sstr, symbols, tan)
 from diofant.abc import A
 from diofant.solvers.deutils import ode_order
 from diofant.solvers.ode import (_linear_coeff_match,
@@ -2833,3 +2833,11 @@ def test_sympyissue_10867():
     v = Eq(g(x).diff(x).diff(x), (x-2)**2 + (x-3)**3)
     ans = Eq(g(x), C1 + C2*x + x**5/20 - 2*x**4/3 + 23*x**3/6 - 23*x**2/2)
     assert dsolve(v, g(x)) == ans
+
+
+def test_diofantissue_281():
+    # test from sympy/sympy#11131
+    ex = -8*cos(x) + sec(x)**2
+    eq = diff(f(x), x, x) + ex
+    assert dsolve(eq) == Eq(f(x),
+                            C1 + x*(C2 - Integral(ex, x)) + Integral(x*ex, x))

--- a/diofant/tests/test_wester.py
+++ b/diofant/tests/test_wester.py
@@ -2475,6 +2475,7 @@ def test_Z4():
 def test_Z5():
     eq = Derivative(f(x), x, 2) + 4*f(x) - sin(2*x)
     sol = dsolve(eq, f(x), init={f(0): 0, f(x).diff(x).subs(x, 0): 0})
+    sol = sol.doit().simplify()
     assert solve(sol, f(x))[0][f(x)] == -x*cos(2*x)/4 + sin(2*x)/8
 
 

--- a/docs/release/notes-0.10.rst
+++ b/docs/release/notes-0.10.rst
@@ -96,3 +96,4 @@ These Sympy issues also were addressed:
 * :sympyissue:`14831` minpoly(-3*sqrt(12*sqrt(2) + 17) + 12*sqrt(2) + 17 -2*sqrt(2)*sqrt(12*sqrt(2) + 17), x) fails
 * :sympyissue:`14476` QQ.algebraic_field(Rational) should be just QQ
 * :sympyissue:`14885` Sympy series gives TypeError on x^(-3/2) * exp(x) at x = 0
+* :sympyissue:`11131` dsolve hangs

--- a/docs/tutorial/intro.rst
+++ b/docs/tutorial/intro.rst
@@ -164,10 +164,11 @@ Solve `x^2 - 2 = 0`.
 Solve the differential equation `f'' - f = e^x`.
 
    >>> f = symbols('f', cls=Function)
-   >>> dsolve(Eq(f(x).diff(x, 2) - f(x), exp(x)), f(x))
-           x ⎛     x⎞    -x
-   f(x) = ℯ ⋅⎜C₂ + ─⎟ + ℯ  ⋅C₁
-             ⎝     2⎠
+   >>> dsolve(Eq(f(x).diff(x, 2) - f(x), exp(x)), f(x)).doit()
+                            ⎛   2⋅x     ⎞
+           x ⎛     x⎞    -x ⎜  ℯ        ⎟
+   f(x) = ℯ ⋅⎜C₂ + ─⎟ + ℯ  ⋅⎜- ──── + C₁⎟
+             ⎝     2⎠       ⎝   4       ⎠
 
 Find the eigenvalues of `\left[\begin{smallmatrix}1 & 2\\2 &
 2\end{smallmatrix}\right]`.

--- a/docs/tutorial/solvers.rst
+++ b/docs/tutorial/solvers.rst
@@ -81,17 +81,17 @@ To represent the differential equation `f''(x) - 2f'(x) + f(x) =
 To solve the ODE, pass it and the function to solve for to
 :func:`~diofant.solvers.ode.dsolve`.
 
-    >>> dsolve(_, f(x))
-            x               cos(x)
-    f(x) = ℯ ⋅(C₁ + C₂⋅x) + ──────
-                              2
+    >>> dsolve(_, f(x)).doit().simplify()
+            x       x        cos(x)
+    f(x) = ℯ ⋅C₁ + ℯ ⋅C₂⋅x + ──────
+                               2
 
 :func:`~diofant.solvers.ode.dsolve` returns an instance of
 :class:`~diofant.core.relational.Eq`.  This is because in general,
 solutions to differential equations cannot be solved explicitly for
 the function.
 
-    >>> dsolve(f(x).diff(x)*(1 - sin(f(x))), f(x))
+    >>> dsolve(f(x).diff(x)*(1 - sin(f(x))), f(x)).doit()
     f(x) + cos(f(x)) = C₁
 
 The arbitrary constants in the solutions from dsolve are symbols of


### PR DESCRIPTION
- [ ] fix comments in ode.py about defaults
- [ ] also fix docstrings
- [ ] release notes
