### PR TITLE
[wip] Fix disjoint criteria for complex roots

### DIFF
--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -1840,12 +1840,10 @@ class ComplexInterval:
             # In this case, both roots could be on western edges.  Lets
             # test that and terminate refinement if it's the case.
 
-            if not any(((not self.F1[3] or 0 in self.I[3][0][1]) and
-                        (not self.F2[3] or 1 in _[1])) for _ in self.I[3]):
+            if 'OO' not in self.Q[3]:
                 return False
-
-            return any(((not other.F1[3] or 0 in _[1]) and
-                        (not other.F2[3] or 1 in _[1])) for _ in other.I[3])
+            else:
+                return 'OO' in other.Q[3]
         return False
 
     def _inner_refine(self):

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -1836,18 +1836,18 @@ class ComplexInterval:
         if im_distinct and (self.ax == other.ax):
             # In this case, both roots could be on western edges.  Lets
             # test that and terminate refinement if it's the case.
-            l1 = dmp_add(dmp_pow(dmp_eval_in(self.f1, self.ax, 0, 1, self.domain),
-                                 2, 0, self.domain),
-                         dmp_pow(dmp_eval_in(self.f2, self.ax, 0, 1, self.domain),
-                                 2, 0, self.domain), 0, self.domain)
-            t1 = dup_count_real_roots(l1, self.domain, inf=self.ay, sup=self.by)
+            f1L4 = dmp_eval_in(self.f1, self.ax, 0, 1, self.domain)
+            f2L4 = dmp_eval_in(self.f2, self.ax, 0, 1, self.domain)
+            S_L4 = [f1L4, f2L4]
+            I_L4 = dup_isolate_real_roots_list(S_L4, self.domain, inf=self.ay, sup=self.by, fast=True, strict=True, basis=True)
+            if not any((not f1L4 or 0 in _[1]) and (not f2L4 or 1 in _[1]) for _ in I_L4):
+                return False
 
-            l2 = dmp_add(dmp_pow(dmp_eval_in(other.f1, other.ax, 0, 1, other.domain),
-                                 2, 0, other.domain),
-                         dmp_pow(dmp_eval_in(other.f2, other.ax, 0, 1, other.domain),
-                                 2, 0, other.domain), 0, other.domain)
-            t2 = dup_count_real_roots(l2, other.domain, inf=other.ay, sup=other.by)
-            return t1 and t2
+            f1L4 = dmp_eval_in(other.f1, other.ax, 0, 1, other.domain)
+            f2L4 = dmp_eval_in(other.f2, other.ax, 0, 1, other.domain)
+            S_L4 = [f1L4, f2L4]
+            I_L4 = dup_isolate_real_roots_list(S_L4, other.domain, inf=other.ay, sup=other.by, fast=True, strict=True, basis=True)
+            return any((not f1L4 or 0 in _[1]) and (not f2L4 or 1 in _[1]) for _ in I_L4)
         return False
 
     def _inner_refine(self):

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -1836,18 +1836,13 @@ class ComplexInterval:
         if im_distinct and (self.ax == other.ax):
             # In this case, both roots could be on western edges.  Lets
             # test that and terminate refinement if it's the case.
-            f1L4 = dmp_eval_in(self.f1, self.ax, 0, 1, self.domain)
-            f2L4 = dmp_eval_in(self.f2, self.ax, 0, 1, self.domain)
-            S_L4 = [f1L4, f2L4]
-            I_L4 = dup_isolate_real_roots_list(S_L4, self.domain, inf=self.ay, sup=self.by, fast=True, strict=True, basis=True)
-            if not any((not f1L4 or 0 in _[1]) and (not f2L4 or 1 in _[1]) for _ in I_L4):
+
+            if not any(((not self.F1[3] or 0 in self.I[3][0][1]) and
+                        (not self.F2[3] or 1 in _[1])) for _ in self.I[3]):
                 return False
 
-            f1L4 = dmp_eval_in(other.f1, other.ax, 0, 1, other.domain)
-            f2L4 = dmp_eval_in(other.f2, other.ax, 0, 1, other.domain)
-            S_L4 = [f1L4, f2L4]
-            I_L4 = dup_isolate_real_roots_list(S_L4, other.domain, inf=other.ay, sup=other.by, fast=True, strict=True, basis=True)
-            return any((not f1L4 or 0 in _[1]) and (not f2L4 or 1 in _[1]) for _ in I_L4)
+            return any(((not other.F1[3] or 0 in _[1]) and
+                        (not other.F2[3] or 1 in _[1])) for _ in other.I[3])
         return False
 
     def _inner_refine(self):

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -1,6 +1,6 @@
 """Real and complex root isolation and refinement algorithms. """
 
-from .densearith import dmp_add, dmp_neg, dmp_pow, dmp_rem, dup_rshift
+from .densearith import dmp_neg, dmp_rem, dup_rshift
 from .densebasic import (dmp_convert, dmp_degree, dmp_LC, dmp_strip, dmp_TC,
                          dmp_terms_gcd, dup_reverse)
 from .densetools import (dmp_eval_in, dup_clear_denoms, dup_diff, dup_eval,

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -1,6 +1,6 @@
 """Real and complex root isolation and refinement algorithms. """
 
-from .densearith import dmp_neg, dmp_rem, dup_rshift
+from .densearith import dmp_add, dmp_neg, dmp_pow, dmp_rem, dup_rshift
 from .densebasic import (dmp_convert, dmp_degree, dmp_LC, dmp_strip, dmp_TC,
                          dmp_terms_gcd, dup_reverse)
 from .densetools import (dmp_eval_in, dup_clear_denoms, dup_diff, dup_eval,
@@ -1833,7 +1833,22 @@ class ComplexInterval:
         if re_distinct:
             return True
         im_distinct = (self.by <= other.ay or other.by <= self.ay)
-        return im_distinct
+        if im_distinct and (self.ax == other.ax):
+            # In this case, both roots could be on western edges.  Lets
+            # test that and terminate refinement if it's the case.
+            l1 = dmp_add(dmp_pow(dmp_eval_in(self.f1, self.ax, 0, 1, self.domain),
+                                 2, 0, self.domain),
+                         dmp_pow(dmp_eval_in(self.f2, self.ax, 0, 1, self.domain),
+                                 2, 0, self.domain), 0, self.domain)
+            t1 = dup_count_real_roots(l1, self.domain, inf=self.ay, sup=self.by)
+
+            l2 = dmp_add(dmp_pow(dmp_eval_in(other.f1, other.ax, 0, 1, other.domain),
+                                 2, 0, other.domain),
+                         dmp_pow(dmp_eval_in(other.f2, other.ax, 0, 1, other.domain),
+                                 2, 0, other.domain), 0, other.domain)
+            t2 = dup_count_real_roots(l2, other.domain, inf=other.ay, sup=other.by)
+            return t1 and t2
+        return False
 
     def _inner_refine(self):
         """Internal one step complex root refinement procedure. """

--- a/diofant/polys/rootoftools.py
+++ b/diofant/polys/rootoftools.py
@@ -291,137 +291,21 @@ class RootOf(Expr):
         return reals
 
     @classmethod
-    def _separate_imaginary_from_complex(cls, complexes):
-        from ..utilities import sift
-
-        def is_imag(c):
-            """
-            return True if all roots are imaginary (ax**2 + b)
-            return False if no roots are imaginary
-            return None if 2 roots are imaginary (ax**N
-            """
-            u, f, k = c
-            deg = f.degree()
-            if f.length() == 2:
-                if deg == 2:
-                    return True  # both imag
-                elif _ispow2(deg):
-                    if f.LC()*f.TC() < 0:
-                        return  # 2 are imag
-            return False  # none are imag
-
-        # separate according to the function
-        sifted = sift(complexes, lambda c: c[1])
-        del complexes
-        imag = []
-        complexes = []
-        for f in sifted:
-            isift = sift(sifted[f], lambda c: is_imag(c))
-            imag.extend(isift.pop(True, []))
-            complexes.extend(isift.pop(False, []))
-            mixed = isift.pop(None, [])
-            assert not isift
-            if not mixed:
-                continue
-            while True:
-                # the non-imaginary ones will be on one side or the other
-                # of the y-axis
-                i = 0
-                while i < len(mixed):
-                    u, f, k = mixed[i]
-                    if u.ax*u.bx > 0:
-                        complexes.append(mixed.pop(i))
-                    else:
-                        i += 1
-                if len(mixed) == 2:
-                    imag.extend(mixed)
-                    break
-                # refine
-                for i, (u, f, k) in enumerate(mixed):
-                    u = u._inner_refine()
-                    mixed[i] = u, f, k
-        return imag, complexes
-
-    @classmethod
-    def _refine_complexes(cls, complexes):
-        """return complexes such that no bounding rectangles of non-conjugate
-        roots would intersect if slid horizontally or vertically/
-        """
-        while complexes:  # break when all are distinct
-            # get the intervals pairwise-disjoint. If rectangles were drawn around
-            # the coordinates of the bounding rectangles, no rectangles would
-            # intersect after this procedure
-            for i, (u, f, k) in enumerate(complexes):
-                for j, (v, g, m) in enumerate(complexes[i + 1:]):
-                    u, v = u.refine_disjoint(v)
-                    complexes[i + j + 1] = (v, g, m)
-
-                complexes[i] = (u, f, k)
-            # Although there are no intersecting rectangles, a given rectangle
-            # might intersect another when slid horizontally. We have to refine
-            # intervals until this is not true so we can sort the roots
-            # unambiguously. Since complex roots come in conjugate pairs, we
-            # will always have 2 rectangles above each other but we should not
-            # have more than that.
-            N = len(complexes)//2 - 1
-            # check x (real) parts: there must be N + 1 disjoint x ranges, i.e.
-            # the first one must be different from N others
-            uu = {(u.ax, u.bx) for u, _, _ in complexes}
-            u = uu.pop()
-            if sum(u[1] <= v[0] or v[1] <= u[0] for v in uu) < N:
-                # refine
-                for i, (u, f, k) in enumerate(complexes):
-                    u = u._inner_refine()
-                    complexes[i] = u, f, k
-            else:
-                # intervals with identical x-values have disjoint y-values or
-                # else they would not be disjoint so there is no need for
-                # further checks
-                break
-        return complexes
-
-    @classmethod
     def _complexes_sorted(cls, complexes):
         """Make complex isolating intervals disjoint and sort roots. """
         if not complexes:
             return []
         cache = {}
 
-        # imaginary roots can cause a problem in terms of sorting since
-        # their x-intervals will never refine as distinct from others
-        # so we handle them separately
-        imag, complexes = cls._separate_imaginary_from_complex(complexes)
-        complexes = cls._refine_complexes(complexes)
+        for i, (u, f, k) in enumerate(complexes):
+            for j, (v, g, m) in enumerate(complexes[i + 1:]):
+                u, v = u.refine_disjoint(v)
+                complexes[i + j + 1] = (v, g, m)
 
-        # sort imaginary roots
-        def key(c):
-            """return, for ax**n+b, +/-root(abs(b/a), b) according to the
-            apparent sign of the imaginary interval, e.g. if the interval
-            were (0, 3) the positive root would be returned.
-            """
-            u, f, k = c
-            r = _root(abs(f.TC()/f.LC()), f.degree())
-            if u.ay < 0 or u.by < 0:
-                return -r
-            return r
-        imag = sorted(imag, key=lambda c: key(c))
+            complexes[i] = (u, f, k)
 
-        # sort complexes and combine with imag
-        if complexes:
-            # key is (x1, y1) e.g. (1, 2)x(3, 4) -> (1,3)
-            complexes = sorted(complexes, key=lambda c: c[0].a)
-            # find insertion point for imaginary
-            for i, c in enumerate(reversed(complexes)):
-                if c[0].bx <= 0:
-                    break
-            i = len(complexes) - i - 1
-            if i:
-                i += 1
-            complexes = complexes[:i] + imag + complexes[i:]
-        else:
-            complexes = imag
+        complexes = sorted(complexes, key=lambda r: (r[0].ax, r[0].ay))
 
-        # update cache
         for root, factor, _ in complexes:
             if factor in cache:
                 cache[factor].append(root)


### PR DESCRIPTION
@smichr, I think that your patch 73fafba was not the right thing for problem it address.  Instead, we should keep refinement process, until real parts will be disjointed.

Key ingredient to terminate this process: we should consider case when tested pair of roots are on the boundary (western edge) of an isolation rectangles.

I don't entirely sure that your solution is wrong, but it clearly does some additional assumptions about sorted roots, e.g. that they come as conjugated pairs (which is not true for polynomials over gaussian rationals).

What do you think?