### PR TITLE
[wip] Add lambdified functions to the Python linecache

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2017 SymPy Development Team,
+Copyright (c) 2006-2018 SymPy Development Team,
               2013-2018 Sergey B Kirpichev
 
 All rights reserved.

--- a/diofant/utilities/tests/test_lambdify.py
+++ b/diofant/utilities/tests/test_lambdify.py
@@ -1,3 +1,4 @@
+import inspect
 import math
 from itertools import product
 
@@ -546,19 +547,7 @@ def test_python_keywords():
 
 def test_lambdify_docstring():
     func = lambdify((w, x, y, z), w + x + y + z)
-    assert func.__doc__ == (
-        "Created with lambdify. Signature:\n\n"
-        "func(w, x, y, z)\n\n"
-        "Expression:\n\n"
-        "w + x + y + z")
-    syms = symbols('a1:26')
-    func = lambdify(syms, sum(syms))
-    assert func.__doc__ == (
-        "Created with lambdify. Signature:\n\n"
-        "func(a1, a2, a3, a4, a5, a6, a7, a8, a9, a10, a11, a12, a13, a14, a15,\n"
-        "        a16, a17, a18, a19, a20, a21, a22, a23, a24, a25)\n\n"
-        "Expression:\n\n"
-        "a1 + a10 + a11 + a12 + a13 + a14 + a15 + a16 + a17 + a18 + a19 + a2 + a20 +...")
+    assert func.__doc__ == "Created with lambdify."
 
 
 # ================= Test special printers ==========================
@@ -611,3 +600,13 @@ def test_Min_Max():
     # see sympy/sympy#10375
     assert lambdify((x, y, z), Min(x, y, z))(1, 2, 3) == 1
     assert lambdify((x, y, z), Max(x, y, z))(1, 2, 3) == 3
+
+
+def test_lambdify_inspect():
+    func = lambdify((w, x, y, z), w + x + y + z, dummify=False)
+    assert 'w + x + y + z' in inspect.getsource(func)
+
+    syms = symbols('a1:26')
+    code = sum(syms)
+    func = lambdify(syms, code, dummify=False)
+    assert str(code) in inspect.getsource(func)


### PR DESCRIPTION
This allows things like inspect.getsource (?? in IPython) to work, and the
code will show up in the tracebacks in IPython.

Presently, the docstring is not included in the source code, because it is
added after the function is execed.

Example:
```
In [1]: f = lambdify(x, 1/x)

In [2]: f(0)
---------------------------------------------------------------------------
ZeroDivisionError                         Traceback (most recent call
last)
<ipython-input-2-6bfbdbfff9c4> in <module>()
----> 1 f(0)

~/venv/dev/lib/python3.5/site-packages/numpy/__init__.py in
<lambda>(_Dummy_15)
----> 1 lambda _Dummy_15: (1/_Dummy_15)

ZeroDivisionError: division by zero

In [3]: f??
Signature: f(_Dummy_15)
Docstring: Created with lambdify.
Source:    lambda _Dummy_15: (1/_Dummy_15)
File:      ~/src/diofant/<lambdifygenerated-1>
Type:      function
```