### PR TITLE
Change Subs interface

### DIFF
--- a/diofant/core/tests/test_args.py
+++ b/diofant/core/tests/test_args.py
@@ -368,7 +368,8 @@ def test_diofant__core__function__Lambda():
 
 
 def test_diofant__core__function__Subs():
-    assert _test_args(Subs(x + y, x, 2))
+    assert _test_args(Subs(x + y, (x, 2)))
+    assert _test_args(Subs(x + y, (x, 2), (y, 1)))
 
 
 def test_diofant__core__function__WildFunction():

--- a/diofant/core/tests/test_function.py
+++ b/diofant/core/tests/test_function.py
@@ -206,58 +206,58 @@ def test_Lambda_equality():
 
 
 def test_Subs():
-    assert Subs(x, x, 0) == Subs(y, y, 0)
-    assert Subs(x, x, 0).subs(x, 1) == Subs(x, x, 0)
-    assert Subs(y, x, 0).subs(y, 1) == Subs(1, x, 0)
-    assert Subs(f(x), x, 0).doit() == f(0)
-    assert Subs(f(x**2), x**2, 0).doit() == f(0)
-    assert Subs(f(x, y, z), (x, y, z), (0, 1, 1)) != \
-        Subs(f(x, y, z), (x, y, z), (0, 0, 1))
-    assert Subs(f(x, y), (x, y, z), (0, 1, 1)) == \
-        Subs(f(x, y), (x, y, z), (0, 1, 2))
-    assert Subs(f(x, y), (x, y, z), (0, 1, 1)) != \
-        Subs(f(x, y) + z, (x, y, z), (0, 1, 0))
-    assert Subs(f(x, y), (x, y), (0, 1)).doit() == f(0, 1)
-    assert Subs(Subs(f(x, y), x, 0), y, 1).doit() == f(0, 1)
-    pytest.raises(ValueError, lambda: Subs(f(x, y), (x, y), (0, 0, 1)))
-    pytest.raises(ValueError, lambda: Subs(f(x, y), (x, x, y), (0, 0, 1)))
+    assert Subs(x, (x, 0)) == Subs(y, (y, 0))
+    assert Subs(x, (x, 0)).subs(x, 1) == Subs(x, (x, 0))
+    assert Subs(y, (x, 0)).subs(y, 1) == Subs(1, (x, 0))
+    assert Subs(f(x), (x, 0)).doit() == f(0)
+    assert Subs(f(x**2), (x**2, 0)).doit() == f(0)
+    assert Subs(f(x, y, z), (x, 0), (y, 1), (z, 1)) != \
+        Subs(f(x, y, z), (x, 0), (y, 0), (z, 1))
+    assert Subs(f(x, y), (x, 0), (y, 1), (z, 1)) == \
+        Subs(f(x, y), (x, 0), (y, 1), (z, 2))
+    assert Subs(f(x, y), (x, 0), (y, 1), (z, 1)) != \
+        Subs(f(x, y) + z, (x, 0), (y, 1), (z, 0))
+    assert Subs(f(x, y), (x, 0), (y, 1)).doit() == f(0, 1)
+    assert Subs(Subs(f(x, y), (x, 0)), (y, 1)).doit() == f(0, 1)
+    pytest.raises(ValueError, lambda: Subs(f(x, y), x))
+    pytest.raises(ValueError, lambda: Subs(f(x, y), (x, 0), (x, 0), (y, 1)))
 
-    assert len(Subs(f(x, y), (x, y), (0, 1)).variables) == 2
-    assert Subs(f(x, y), (x, y), (0, 1)).point == Tuple(0, 1)
+    assert len(Subs(f(x, y), (x, 0), (y, 1)).variables) == 2
+    assert Subs(f(x, y), (x, 0), (y, 1)).point == Tuple(0, 1)
 
-    assert Subs(f(x), x, 0) == Subs(f(y), y, 0)
-    assert Subs(f(x, y), (x, y), (0, 1)) == Subs(f(x, y), (y, x), (1, 0))
-    assert Subs(f(x)*y, (x, y), (0, 1)) == Subs(f(y)*x, (y, x), (0, 1))
-    assert Subs(f(x)*y, (x, y), (1, 1)) == Subs(f(y)*x, (x, y), (1, 1))
+    assert Subs(f(x), (x, 0)) == Subs(f(y), (y, 0))
+    assert Subs(f(x, y), (x, 0), (y, 1)) == Subs(f(x, y), (y, 1), (x, 0))
+    assert Subs(f(x)*y, (x, 0), (y, 1)) == Subs(f(y)*x, (y, 0), (x, 1))
+    assert Subs(f(x)*y, (x, 1), (y, 1)) == Subs(f(y)*x, (x, 1), (y, 1))
 
-    assert Subs(f(x), x, 0).subs(x, 1).doit() == f(0)
-    assert Subs(f(x), x, y).subs(y, 0) == Subs(f(x), x, 0)
-    assert Subs(y*f(x), x, y).subs(y, 2) == Subs(2*f(x), x, 2)
-    assert (2 * Subs(f(x), x, 0)).subs(Subs(f(x), x, 0), y) == 2*y
+    assert Subs(f(x), (x, 0)).subs(x, 1).doit() == f(0)
+    assert Subs(f(x), (x, y)).subs(y, 0) == Subs(f(x), (x, 0))
+    assert Subs(y*f(x), (x, y)).subs(y, 2) == Subs(2*f(x), (x, 2))
+    assert (2 * Subs(f(x), (x, 0))).subs(Subs(f(x), (x, 0)), y) == 2*y
 
-    assert Subs(f(x), x, 0).free_symbols == set()
-    assert Subs(f(x, y), x, z).free_symbols == {y, z}
+    assert Subs(f(x), (x, 0)).free_symbols == set()
+    assert Subs(f(x, y), (x, z)).free_symbols == {y, z}
 
-    assert Subs(f(x).diff(x), x, 0).doit(), Subs(f(x).diff(x), x, 0)
-    assert Subs(1 + f(x).diff(x), x, 0).doit(), 1 + Subs(f(x).diff(x), x, 0)
-    assert Subs(y*f(x, y).diff(x), (x, y), (0, 2)).doit() == \
-        2*Subs(Derivative(f(x, 2), x), x, 0)
-    assert Subs(y**2*f(x), x, 0).diff(y) == 2*y*f(0)
+    assert Subs(f(x).diff(x), (x, 0)).doit(), Subs(f(x).diff(x), (x, 0))
+    assert Subs(1 + f(x).diff(x), (x, 0)).doit(), 1 + Subs(f(x).diff(x), (x, 0))
+    assert Subs(y*f(x, y).diff(x), (x, 0), (y, 2)).doit() == \
+        2*Subs(Derivative(f(x, 2), x), (x, 0))
+    assert Subs(y**2*f(x), (x, 0)).diff(y) == 2*y*f(0)
 
-    e = Subs(y**2*f(x), x, y)
+    e = Subs(y**2*f(x), (x, y))
     assert e.diff(y) == e.doit().diff(y) == y**2*Derivative(f(y), y) + 2*y*f(y)
 
-    assert Subs(f(x), x, 0) + Subs(f(x), x, 0) == 2*Subs(f(x), x, 0)
-    e1 = Subs(z*f(x), x, 1)
-    e2 = Subs(z*f(y), y, 1)
+    assert Subs(f(x), (x, 0)) + Subs(f(x), (x, 0)) == 2*Subs(f(x), (x, 0))
+    e1 = Subs(z*f(x), (x, 1))
+    e2 = Subs(z*f(y), (y, 1))
     assert e1 + e2 == 2*e1
     assert e1.__hash__() == e2.__hash__()
-    assert Subs(z*f(x + 1), x, 1) not in [ e1, e2 ]
+    assert Subs(z*f(x + 1), (x, 1)) not in (e1, e2)
     assert Derivative(f(x), x).subs(x, g(x)) == Derivative(f(g(x)), g(x))
     assert Derivative(f(x), x).subs(x, x + y) == Subs(Derivative(f(x), x),
-                                                      (x,), (x + y))
-    assert Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).n(2, strict=False) == \
-        Subs(f(x)*cos(y) + z, (x, y), (0, pi/3)).evalf(2, strict=False) == \
+                                                      (x, x + y))
+    assert Subs(f(x)*cos(y) + z, (x, 0), (y, pi/3)).n(2, strict=False) == \
+        Subs(f(x)*cos(y) + z, (x, 0), (y, pi/3)).evalf(2, strict=False) == \
         z + Rational('1/2').n(2)*f(0)
 
     assert f(x).diff(x).subs(x, 0).subs(x, y) == f(x).diff(x).subs(x, 0)
@@ -267,7 +267,7 @@ def test_Subs():
 @pytest.mark.xfail
 def test_Subs2():
     # this reflects a limitation of subs(), probably won't fix
-    assert Subs(f(x), x**2, x).doit() == f(sqrt(x))
+    assert Subs(f(x), (x**2, x)).doit() == f(sqrt(x))
 
 
 def test_expand_function():
@@ -300,23 +300,19 @@ def test_function_comparable_infinities():
 def test_deriv1():
     # These all requre derivatives evaluated at a point (issue sympy/sympy#4719) to work.
     # See issue sympy/sympy#4624
-    assert f(2*x).diff(x) == 2*Subs(Derivative(f(x), x), Tuple(x), Tuple(2*x))
+    assert f(2*x).diff(x) == 2*Subs(Derivative(f(x), x), (x, 2*x))
     assert (f(x)**3).diff(x) == 3*f(x)**2*f(x).diff(x)
-    assert (
-        f(2*x)**3).diff(x) == 6*f(2*x)**2*Subs(Derivative(f(x), x), Tuple(x),
-                                               Tuple(2*x))
+    assert (f(2*x)**3).diff(x) == 6*f(2*x)**2*Subs(Derivative(f(x), x), (x, 2*x))
 
-    assert f(2 + x).diff(x) == Subs(Derivative(f(x), x), Tuple(x), Tuple(x + 2))
-    assert f(2 + 3*x).diff(x) == 3*Subs(Derivative(f(x), x), Tuple(x),
-                                        Tuple(3*x + 2))
-    assert f(3*sin(x)).diff(x) == 3*cos(x)*Subs(Derivative(f(x), x),
-                                                Tuple(x), Tuple(3*sin(x)))
+    assert f(2 + x).diff(x) == Subs(Derivative(f(x), x), (x, x + 2))
+    assert f(2 + 3*x).diff(x) == 3*Subs(Derivative(f(x), x), (x, 3*x + 2))
+    assert f(3*sin(x)).diff(x) == 3*cos(x)*Subs(Derivative(f(x), x), (x, 3*sin(x)))
 
     # See issue sympy/sympy#8510
-    assert f(x, x + z).diff(x) == Subs(Derivative(f(y, x + z), y), Tuple(y), Tuple(x)) \
-        + Subs(Derivative(f(x, y), y), Tuple(y), Tuple(x + z))
-    assert f(x, x**2).diff(x) == Subs(Derivative(f(y, x**2), y), Tuple(y), Tuple(x)) \
-        + 2*x*Subs(Derivative(f(x, y), y), Tuple(y), Tuple(x**2))
+    assert f(x, x + z).diff(x) == Subs(Derivative(f(y, x + z), y), (y, x)) \
+        + Subs(Derivative(f(x, y), y), (y, x + z))
+    assert f(x, x**2).diff(x) == Subs(Derivative(f(y, x**2), y), (y, x)) \
+        + 2*x*Subs(Derivative(f(x, y), y), (y, x**2))
 
 
 def test_deriv2():
@@ -549,14 +545,13 @@ def test_diff_wrt():
 
     # Chain rule cases
     assert f(g(x)).diff(x) == \
-        Subs(Derivative(f(x), x), (x,), (g(x),))*Derivative(g(x), x)
+        Subs(Derivative(f(x), x), (x, g(x)))*Derivative(g(x), x)
     assert diff(f(g(x), h(x)), x) == \
-        Subs(Derivative(f(y, h(x)), y), (y,), (g(x),))*Derivative(g(x), x) + \
-        Subs(Derivative(f(g(x), y), y), (y,), (h(x),))*Derivative(h(x), x)
-    assert f(
-        sin(x)).diff(x) == Subs(Derivative(f(x), x), (x,), (sin(x),))*cos(x)
+        Subs(Derivative(f(y, h(x)), y), (y, g(x)))*Derivative(g(x), x) + \
+        Subs(Derivative(f(g(x), y), y), (y, h(x)))*Derivative(h(x), x)
+    assert f(sin(x)).diff(x) == Subs(Derivative(f(x), x), (x, sin(x)))*cos(x)
 
-    assert diff(f(g(x)), g(x)) == Subs(Derivative(f(x), x), (x,), (g(x),))
+    assert diff(f(g(x)), g(x)) == Subs(Derivative(f(x), x), (x, g(x)))
 
 
 def test_diff_wrt_func_subs():
@@ -671,22 +666,20 @@ def test_sympyissue_7068():
     func1_y = func1.diff(y1)
     func2_y = func2.diff(y2)
     assert func1_y != func2_y
-    z1 = Subs(f(a), a, y1)
-    z2 = Subs(f(a), a, y2)
+    z1 = Subs(f(a), (a, y1))
+    z2 = Subs(f(a), (a, y2))
     assert z1 != z2
 
 
 def test_sympyissue_7231():
     ans1 = f(x).series(x, a)
     _xi_1 = ans1.atoms(Dummy).pop()
-    res = (f(a) + (-a + x)*Subs(Derivative(f(_xi_1), _xi_1), (_xi_1,), (a,)) +
-           (-a + x)**2*Subs(Derivative(f(_xi_1), _xi_1, _xi_1), (_xi_1,), (a,))/2 +
-           (-a + x)**3*Subs(Derivative(f(_xi_1), _xi_1, _xi_1, _xi_1),
-                            (_xi_1,), (a,))/6 +
-           (-a + x)**4*Subs(Derivative(f(_xi_1), _xi_1, _xi_1, _xi_1, _xi_1),
-                            (_xi_1,), (a,))/24 +
+    res = (f(a) + (-a + x)*Subs(Derivative(f(_xi_1), _xi_1), (_xi_1, a)) +
+           (-a + x)**2*Subs(Derivative(f(_xi_1), _xi_1, _xi_1), (_xi_1, a))/2 +
+           (-a + x)**3*Subs(Derivative(f(_xi_1), _xi_1, _xi_1, _xi_1), (_xi_1, a))/6 +
+           (-a + x)**4*Subs(Derivative(f(_xi_1), _xi_1, _xi_1, _xi_1, _xi_1), (_xi_1, a))/24 +
            (-a + x)**5*Subs(Derivative(f(_xi_1), _xi_1, _xi_1, _xi_1, _xi_1, _xi_1),
-                            (_xi_1,), (a,))/120 + O((-a + x)**6, (x, a)))
+                            (_xi_1, a))/120 + O((-a + x)**6, (x, a)))
     assert res == ans1
     ans2 = f(x).series(x, a)
     assert res == ans2
@@ -729,17 +722,17 @@ def test_sympyissue_11313():
 
 
 def test_sympyissue_12005():
-    e1 = Subs(Derivative(f(x), x), (x,), (x,))
+    e1 = Subs(Derivative(f(x), x), (x, x))
     assert e1.diff(x) == Derivative(f(x), x, x)
-    e2 = Subs(Derivative(f(x), x), (x,), (x**2 + 1,))
-    assert e2.diff(x) == 2*x*Subs(Derivative(f(x), x, x), (x,), (x**2 + 1,))
-    e3 = Subs(Derivative(f(x) + y**2 - y, y), (y,), (y**2,))
+    e2 = Subs(Derivative(f(x), x), (x, x**2 + 1))
+    assert e2.diff(x) == 2*x*Subs(Derivative(f(x), x, x), (x, x**2 + 1))
+    e3 = Subs(Derivative(f(x) + y**2 - y, y), (y, y**2))
     assert e3.diff(y) == 4*y
-    e4 = Subs(Derivative(f(x + y), y), (y,), (x**2))
+    e4 = Subs(Derivative(f(x + y), y), (y, x**2))
     assert e4.diff(y) == 0
-    e5 = Subs(Derivative(f(x), x), (y, z), (y, z))
+    e5 = Subs(Derivative(f(x), x), (y, y), (z, z))
     assert e5.diff(x) == Derivative(f(x), x, x)
-    assert f(g(x)).diff(g(x), g(x)) == Subs(Derivative(f(y), y, y), (y,), (g(x),))
+    assert f(g(x)).diff(g(x), g(x)) == Subs(Derivative(f(y), y, y), (y, g(x)))
 
 
 def test_sympyissue_13098():

--- a/diofant/core/tests/test_subs.py
+++ b/diofant/core/tests/test_subs.py
@@ -190,7 +190,7 @@ def test_mul():
     assert (x*y/z).subs(x, 1/a) == y/(z*a)
     assert (2*x*y).subs(5*x*y, z) != 2*z/5
     assert (x*y*A).subs(x*y, a) == a*A
-    assert Subs(x*y*A, x*y, a).is_commutative is False
+    assert Subs(x*y*A, (x*y, a)).is_commutative is False
     assert (x**2*y**(3*x/2)).subs(x*y**(x/2), 2) == 4*y**(x/2)
     assert (x*exp(x*2)).subs(x*exp(x), 2) == 2*exp(x)
     assert ((x**(2*y))**3).subs(x**y, 2) == 64
@@ -198,7 +198,7 @@ def test_mul():
     assert (x*y*(1 + x)*(1 + x*y)).subs(x*y, 2) == 6*(1 + x)
     assert ((1 + A*B)*A*B).subs(A*B, x*A*B)
     assert (x*a/z).subs(x/z, A) == a*A
-    assert Subs(x*a/z, x/z, A).is_commutative is False
+    assert Subs(x*a/z, (x/z, A)).is_commutative is False
     assert (x**3*A).subs(x**2*A, a) == a*x
     assert (x**2*A*B).subs(x**2*B, a) == a*A
     assert (x**2*A*B).subs(x**2*A, a) == a*B
@@ -557,7 +557,7 @@ def test_simultaneous_subs():
     assert (x/y).subs(reps, simultaneous=True) == \
         (y/x).subs(reps, simultaneous=True)
     assert Derivative(x, y, z).subs(reps, simultaneous=True) == \
-        Subs(Derivative(0, y, z), (y,), (0,))
+        Subs(Derivative(0, y, z), (y, 0))
 
 
 def test_sympyissue_6419_6421():
@@ -681,12 +681,12 @@ def test_sympyissue_11746():
 
 def test_diofantissue_376():
     f = symbols('f', cls=Function)
-    e1 = Subs(Derivative(f(x), x), x, y*z)
-    e2 = Subs(Derivative(f(t), t), t, y*z)
+    e1 = Subs(Derivative(f(x), x), (x, y*z))
+    e2 = Subs(Derivative(f(t), t), (t, y*z))
     assert (x*e1).subs(e2, y) == x*y
-    e3 = Subs(Derivative(f(t), t), t, y*z**2)
+    e3 = Subs(Derivative(f(t), t), (t, y*z**2))
     assert e3.subs(e2, y) == e3
-    e4 = Subs(Derivative(f(t), t, t), t, y*z)
+    e4 = Subs(Derivative(f(t), t, t), (t, y*z))
     assert e4.subs(e2, y) == e4
 
 
@@ -698,5 +698,5 @@ def test_aresame_ordering():
 
 def test_underscores():
     _0, _1 = symbols('_0 _1')
-    e = Subs(_0 + _1, (_0, _1), (1, 0))
+    e = Subs(_0 + _1, (_0, 1), (_1, 0))
     assert e._expr == Symbol('__0') + Symbol('__1')

--- a/diofant/diffgeom/tests/test_diffgeom.py
+++ b/diofant/diffgeom/tests/test_diffgeom.py
@@ -244,7 +244,7 @@ def test_sympyissue_11799():
     d = Symbol('d')
 
     assert (R[0, 1, 0, 1] ==
-            -Subs(Derivative(f(d, x[1]), d, d), (d,), (x[0],))/f(x[0], x[1]) -
-            Subs(Derivative(f(x[0], d), d, d), (d,), (x[1],))/f(x[0], x[1]) +
-            Subs(Derivative(f(d, x[1]), d), (d,), (x[0],))**2/f(x[0], x[1])**2 +
-            Subs(Derivative(f(x[0], d), d), (d,), (x[1],))**2/f(x[0], x[1])**2)
+            -Subs(Derivative(f(d, x[1]), d, d), (d, x[0]))/f(x[0], x[1]) -
+            Subs(Derivative(f(x[0], d), d, d), (d, x[1]))/f(x[0], x[1]) +
+            Subs(Derivative(f(d, x[1]), d), (d, x[0]))**2/f(x[0], x[1])**2 +
+            Subs(Derivative(f(x[0], d), d), (d, x[1]))**2/f(x[0], x[1])**2)

--- a/diofant/printing/latex.py
+++ b/diofant/printing/latex.py
@@ -530,7 +530,7 @@ class LatexPrinter(Printer):
             return r"%s %s" % (tex, self._print(expr.expr))
 
     def _print_Subs(self, subs):
-        expr, old, new = subs.args
+        expr, old, new = subs.expr, subs.variables, subs.point
         latex_expr = self._print(expr)
         latex_old = (self._print(e) for e in old)
         latex_new = (self._print(e) for e in new)  # pragma: no branch

--- a/diofant/printing/pretty/tests/test_pretty.py
+++ b/diofant/printing/pretty/tests/test_pretty.py
@@ -187,9 +187,9 @@ Limit(sin(x)/x, x, 0)
 
 SUBS:
 
-Subs(f(x), x, ph**2)
-Subs(f(x).diff(x), x, 0)
-Subs(f(x).diff(x)/y, (x, y), (0, Rational(1, 2)))
+Subs(f(x), (x, ph**2))
+Subs(f(x).diff(x), (x, 0))
+Subs(f(x).diff(x)/y, (x, 0), (y, Rational(1, 2)))
 
 
 ORDER:
@@ -4142,7 +4142,7 @@ n = -∞       \
 
 def test_pretty_Subs():
     f = Function('f')
-    expr = Subs(f(x), x, ph**2)
+    expr = Subs(f(x), (x, ph**2))
     ascii_str = \
         """\
 (f(x))|     2\n\
@@ -4157,7 +4157,7 @@ def test_pretty_Subs():
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
 
-    expr = Subs(f(x).diff(x), x, 0)
+    expr = Subs(f(x).diff(x), (x, 0))
     ascii_str = \
         """\
 /d       \\|   \n\
@@ -4174,7 +4174,7 @@ def test_pretty_Subs():
     assert pretty(expr) == ascii_str
     assert upretty(expr) == unicode_str
 
-    expr = Subs(f(x).diff(x)/y, (x, y), (0, Rational(1, 2)))
+    expr = Subs(f(x).diff(x)/y, (x, 0), (y, Rational(1, 2)))
     ascii_str = \
         """\
 /d       \\|          \n\

--- a/diofant/printing/tests/test_latex.py
+++ b/diofant/printing/tests/test_latex.py
@@ -525,9 +525,9 @@ def test_latex_derivatives():
 
 
 def test_latex_subs():
-    assert latex(Subs(x, x, 1)) == r'\left. x \right|_{\substack{ x=1 }}'
-    assert latex(Subs(x*y, (
-        x, y), (1, 2))) == r'\left. x y \right|_{\substack{ x=1\\ y=2 }}'
+    assert latex(Subs(x, (x, 1))) == r'\left. x \right|_{\substack{ x=1 }}'
+    assert latex(Subs(x*y, (x, 1),
+                      (y, 2))) == r'\left. x y \right|_{\substack{ x=1\\ y=2 }}'
 
 
 def test_latex_integrals():

--- a/diofant/series/tests/test_series.py
+++ b/diofant/series/tests/test_series.py
@@ -85,22 +85,22 @@ def test_sympyissue_5223():
 def test_sympyissue_3978():
     f = Function('f')
     assert f(x).series(x, 0, 3, dir='-') == \
-        f(0) + x*Subs(Derivative(f(x), x), (x,), (0,)) + \
-        x**2*Subs(Derivative(f(x), x, x), (x,), (0,))/2 + O(x**3)
+        f(0) + x*Subs(Derivative(f(x), x), (x, 0)) + \
+        x**2*Subs(Derivative(f(x), x, x), (x, 0))/2 + O(x**3)
     assert f(x).series(x, 0, 3) == \
-        f(0) + x*Subs(Derivative(f(x), x), (x,), (0,)) + \
-        x**2*Subs(Derivative(f(x), x, x), (x,), (0,))/2 + O(x**3)
+        f(0) + x*Subs(Derivative(f(x), x), (x, 0)) + \
+        x**2*Subs(Derivative(f(x), x, x), (x, 0))/2 + O(x**3)
     assert f(x**2).series(x, 0, 3) == \
-        f(0) + x**2*Subs(Derivative(f(x), x), (x,), (0,)) + O(x**3)
+        f(0) + x**2*Subs(Derivative(f(x), x), (x, 0)) + O(x**3)
     assert f(x**2+1).series(x, 0, 3) == \
-        f(1) + x**2*Subs(Derivative(f(x), x), (x,), (1,)) + O(x**3)
+        f(1) + x**2*Subs(Derivative(f(x), x), (x, 1)) + O(x**3)
 
     class TestF(Function):
         pass
 
     assert TestF(x).series(x, 0, 3) == TestF(0) + \
-        x*Subs(Derivative(TestF(x), x), (x,), (0,)) + \
-        x**2*Subs(Derivative(TestF(x), x, x), (x,), (0,))/2 + O(x**3)
+        x*Subs(Derivative(TestF(x), x), (x, 0)) + \
+        x**2*Subs(Derivative(TestF(x), x, x), (x, 0))/2 + O(x**3)
 
 
 def test_sympyissue_5852():

--- a/diofant/simplify/tests/test_cse.py
+++ b/diofant/simplify/tests/test_cse.py
@@ -209,21 +209,18 @@ def test_dont_cse_tuples():
     f = Function("f")
     g = Function("g")
 
-    name_val, (expr,) = cse(
-        Subs(f(x, y), (x, y), (0, 1))
-        + Subs(g(x, y), (x, y), (0, 1)))
+    name_val, (expr,) = cse(Subs(f(x, y), (x, 0), (y, 1)) +
+                            Subs(g(x, y), (x, 0), (y, 1)))
 
     assert name_val == []
-    assert expr == (Subs(f(x, y), (x, y), (0, 1))
-                    + Subs(g(x, y), (x, y), (0, 1)))
+    assert expr == (Subs(f(x, y), (x, 0), (y, 1))
+                    + Subs(g(x, y), (x, 0), (y, 1)))
 
-    name_val, (expr,) = cse(
-        Subs(f(x, y), (x, y), (0, x + y))
-        + Subs(g(x, y), (x, y), (0, x + y)))
+    name_val, (expr,) = cse(Subs(f(x, y), (x, 0), (y, x + y)) +
+                            Subs(g(x, y), (x, 0), (y, x + y)))
 
     assert name_val == [(x0, x + y)]
-    assert expr == Subs(f(x, y), (x, y), (0, x0)) + \
-        Subs(g(x, y), (x, y), (0, x0))
+    assert expr == Subs(f(x, y), (x, 0), (y, x0)) + Subs(g(x, y), (x, 0), (y, x0))
 
 
 def test_pow_invpow():

--- a/diofant/simplify/tests/test_trigsimp.py
+++ b/diofant/simplify/tests/test_trigsimp.py
@@ -72,7 +72,7 @@ def test_trigsimp2():
     assert trigsimp(sin(x)**2*sin(y)**2 + sin(x)**2*cos(y)**2 + cos(x)**2,
                     recursive=True) == 1
     assert trigsimp(
-        Subs(x, x, sin(y)**2 + cos(y)**2)) == Subs(x, x, 1)
+        Subs(x, (x, sin(y)**2 + cos(y)**2))) == Subs(x, (x, 1))
 
 
 def test_sympyissue_4373():

--- a/diofant/solvers/ode.py
+++ b/diofant/solvers/ode.py
@@ -2848,7 +2848,7 @@ def _handle_Integral(expr, func, order, hint):
         sol = (expr.doit()).subs(y, f(x))
         del y
     elif hint == "1st_exact_Integral":
-        sol = Eq(Subs(expr.lhs, y, f(x)), expr.rhs)
+        sol = Eq(Subs(expr.lhs, (y, f(x))), expr.rhs)
         del y
     elif hint == "nth_linear_constant_coeff_homogeneous":
         sol = expr

--- a/diofant/solvers/pde.py
+++ b/diofant/solvers/pde.py
@@ -401,7 +401,7 @@ def checkpdesol(pde, sol, func=None, solve_for_func=True):
     >>> assert checkpdesol(eq, sol)[0]
     >>> eq = x*f(x, y) + f(x, y).diff(x)
     >>> checkpdesol(eq, sol)
-    (False, E**(-6*x/25 - 8*y/25)*(x*F(4*x - 3*y) - 6*F(4*x - 3*y)/25 + 4*Subs(Derivative(F(_xi_1), _xi_1), (_xi_1,), (4*x - 3*y,))))
+    (False, E**(-6*x/25 - 8*y/25)*(x*F(4*x - 3*y) - 6*F(4*x - 3*y)/25 + 4*Subs(Derivative(F(_xi_1), _xi_1), (_xi_1, 4*x - 3*y))))
     """
 
     # Converting the pde into an equation
@@ -588,7 +588,7 @@ def pde_1st_linear_constant_coeff(eq, func, order, match, solvefun):
     genterm = (1/(b**2 + c**2))*Integral(
         (1/expterm*e).subs(solvedict), (xi, b*x + c*y))
     return Eq(f(x, y), Subs(expterm*(functerm + genterm),
-                            (eta, xi), (c*x - b*y, b*x + c*y)))
+                            (eta, c*x - b*y), (xi, b*x + c*y)))
 
 
 def pde_1st_linear_variable_coeff(eq, func, order, match, solvefun):

--- a/diofant/solvers/tests/test_ode.py
+++ b/diofant/solvers/tests/test_ode.py
@@ -1015,8 +1015,8 @@ def test_solve_init():
              f(L).diff(L, 3): 0}
     init2 = {f(0): 0,
              f(x).diff(x).subs(x, 0): 0,
-             Subs(f(x).diff(x, 2), x, L): 0,
-             Subs(f(x).diff(x, 3), x, L): 0}
+             Subs(f(x).diff(x, 2), (x, L)): 0,
+             Subs(f(x).diff(x, 3), (x, L)): 0}
 
     solved_constants1 = solve_init(sols, funcs, constants, init1)
     solved_constants2 = solve_init(sols, funcs, constants, init2)
@@ -2807,7 +2807,7 @@ def test_sympyissue_11290():
     assert (str(s1) ==
             "Eq(Subs(Integral(-x*sin(_y) + _y**2 "
             "- Integral(-sin(_y), x), _y) + "
-            "Integral(cos(_y), x), (_y,), (f(x),)), C1)")
+            "Integral(cos(_y), x), (_y, f(x))), C1)")
     assert s1.doit() == s0
 
 

--- a/docs/release/notes-0.10.rst
+++ b/docs/release/notes-0.10.rst
@@ -43,6 +43,7 @@ Compatibility breaks
 * Removed ``p`` and ``q`` properties of :class:`~diofant.core.numbers.Rational`, see :pull:`654`.
 * Removed ``@public`` decorator, see :pull:`666`.
 * Removed ``dummy_eq()`` method from :class:`~diofant.core.basic.Basic`, see :pull:`666`.
+* :class:`~diofant.core.function.Subs` now support only ``Subs(expr, (var1, val1), (var2, val2), ...)`` syntax, see :pull:`667`.
 
 Minor changes
 =============


### PR DESCRIPTION
Like https://github.com/sympy/sympy/pull/2613.

In this way, Subs will be more consistent with subs method, which take two scalar argument or one iterable container of pairs.

- [x] rebase, commit msg
- [x] release notes
- [x] ~~keep Subs(expr, sym, var) "scalar" syntax?~~