### PR TITLE
Fix #714

### DIFF
--- a/diofant/integrals/rationaltools.py
+++ b/diofant/integrals/rationaltools.py
@@ -223,7 +223,7 @@ def ratint_logpart(f, g, x, t=None):
             h = R_map[i]
             h_lc = Poly(h.LC(), t, field=True)
 
-            c, h_lc_sqf = h_lc.sqf_list(all=True)
+            c, h_lc_sqf = h_lc.sqf_list()
             _include_sign(c, h_lc_sqf)
 
             for a, j in h_lc_sqf:

--- a/diofant/integrals/rationaltools.py
+++ b/diofant/integrals/rationaltools.py
@@ -1,6 +1,6 @@
 """This module implements tools for integrating rational functions. """
 
-from ..core import Dummy, I, Integer, Lambda, S, Symbol, symbols
+from ..core import Dummy, I, Integer, Lambda, Symbol, symbols
 from ..domains import ZZ
 from ..functions import atan, log
 from ..polys import Poly, RootSum, cancel, resultant, roots
@@ -183,7 +183,7 @@ def ratint_logpart(f, g, x, t=None):
       Poly(3*_t**2 + 1, _t, domain='ZZ'))]
     >>> ratint_logpart(Poly(12, x), Poly(x**2 - x - 2, x), x)
     [(Poly(x - 3*_t/8 - 1/2, x, domain='QQ[_t]'),
-      Poly(-_t**2 + 16, _t, domain='ZZ'))]
+      Poly(_t**2 - 16, _t, domain='ZZ'))]
 
     See Also
     ========
@@ -206,13 +206,7 @@ def ratint_logpart(f, g, x, t=None):
     for r in R:
         R_map[r.degree()] = r
 
-    def _include_sign(c, sqf):
-        if (c < 0) is S.true:
-            h, k = sqf[0]
-            sqf[0] = h*c, k
-
     C, res_sqf = res.sqf_list()
-    _include_sign(C, res_sqf)
 
     for q, i in res_sqf:
         _, q = q.primitive()
@@ -224,7 +218,6 @@ def ratint_logpart(f, g, x, t=None):
             h_lc = Poly(h.LC(), t, field=True)
 
             c, h_lc_sqf = h_lc.sqf_list()
-            _include_sign(c, h_lc_sqf)
 
             for a, j in h_lc_sqf:
                 h = h.quo(Poly(a.gcd(q)**j, x))

--- a/diofant/integrals/risch.py
+++ b/diofant/integrals/risch.py
@@ -897,7 +897,11 @@ def splitfactor_sqf(p, DE, coefficientD=False, z=None, basic=False):
 
     S = []
     N = []
-    p_sqf = p.sqf_list_include()
+
+    c_sqf, p_sqf = p.sqf_list()
+    if not c_sqf.is_one:
+        p_sqf.insert(0, (c_sqf, 1))
+
     if p.is_zero:
         return ((p, 1),), ()
 
@@ -1194,7 +1198,9 @@ def residue_reduce(a, d, DE, z=None, invert=True):
                 continue
             h_lc = Poly(h.as_poly(DE.t).LC(), DE.t, field=True)
 
-            h_lc_sqf = h_lc.sqf_list_include()
+            c_sqf, h_lc_sqf = h_lc.sqf_list()
+            if not c_sqf.is_one:
+                h_lc_sqf.insert(0, (c_sqf, 1))
 
             for a, j in h_lc_sqf:
                 h = Poly(h, DE.t, field=True).exquo(Poly(gcd(a, s**j, *kkinv),
@@ -1212,7 +1218,8 @@ def residue_reduce(a, d, DE, z=None, invert=True):
 
                 h = Poly(dict(zip(h.monoms(), coeffs)), DE.t)
 
-            H.append((s, h))
+            if not s.is_one:
+                H.append((s, h))
 
     b = all(not cancel(i.as_expr()).has(DE.t, z) for i, _ in Np)
 

--- a/diofant/integrals/risch.py
+++ b/diofant/integrals/risch.py
@@ -1194,7 +1194,7 @@ def residue_reduce(a, d, DE, z=None, invert=True):
                 continue
             h_lc = Poly(h.as_poly(DE.t).LC(), DE.t, field=True)
 
-            h_lc_sqf = h_lc.sqf_list_include(all=True)
+            h_lc_sqf = h_lc.sqf_list_include()
 
             for a, j in h_lc_sqf:
                 h = Poly(h, DE.t, field=True).exquo(Poly(gcd(a, s**j, *kkinv),

--- a/diofant/integrals/tests/test_rationaltools.py
+++ b/diofant/integrals/tests/test_rationaltools.py
@@ -120,10 +120,8 @@ def test_ratint():
 
 
 def test_ratint_logpart():
-    assert ratint_logpart(x, x**2 - 9, x, t) == \
-        [(Poly(x**2 - 9, x), Poly(-2*t + 1, t))]
-    assert ratint_logpart(x**2, x**3 - 5, x, t) == \
-        [(Poly(x**3 - 5, x), Poly(-3*t + 1, t))]
+    assert ratint_logpart(x, x**2 - 9, x, t) == [(Poly(x**2 - 9), Poly(2*t - 1))]
+    assert ratint_logpart(x**2, x**3 - 5, x, t) == [(Poly(x**3 - 5), Poly(3*t - 1))]
 
 
 def test_sympyissue_5414():

--- a/diofant/polys/compatibility.py
+++ b/diofant/polys/compatibility.py
@@ -47,8 +47,9 @@ from .rootisolation import (dup_count_complex_roots, dup_count_real_roots,
                             dup_isolate_real_roots_list,
                             dup_isolate_real_roots_sqf, dup_refine_real_root,
                             dup_root_upper_bound, dup_sturm)
-from .sqfreetools import (dmp_sqf_list, dmp_sqf_list_include, dmp_sqf_norm,
-                          dmp_sqf_part, dup_gff_list)
+from .sqfreetools import (dmp_sqf_list_in, dmp_sqf_list_include_in,
+                          dmp_sqf_norm, dmp_sqf_p_in, dmp_sqf_part_in,
+                          dup_gff_list)
 
 
 __all__ = ('IPolys',)
@@ -536,15 +537,18 @@ class IPolys:
         s, F, R = dmp_sqf_norm(self.to_dense(f), self.ngens-1, self.domain)
         return s, self.from_dense(F), self.to_ground().from_dense(R)
 
-    def dmp_sqf_part(self, f):
-        return self.from_dense(dmp_sqf_part(self.to_dense(f), self.ngens-1, self.domain))
+    def dmp_sqf_p_in(self, f, N):
+        return dmp_sqf_p_in(self.to_dense(f), N, self.ngens-1, self.domain)
 
-    def dmp_sqf_list(self, f):
-        coeff, factors = dmp_sqf_list(self.to_dense(f), self.ngens-1, self.domain)
+    def dmp_sqf_part_in(self, f, N):
+        return self.from_dense(dmp_sqf_part_in(self.to_dense(f), N, self.ngens-1, self.domain))
+
+    def dmp_sqf_list_in(self, f, N):
+        coeff, factors = dmp_sqf_list_in(self.to_dense(f), N, self.ngens-1, self.domain)
         return self.from_dense(coeff), [(self.from_dense(g), k) for g, k in factors]
 
-    def dmp_sqf_list_include(self, f):
-        factors = dmp_sqf_list_include(self.to_dense(f), self.ngens-1, self.domain)
+    def dmp_sqf_list_include_in(self, f, N):
+        factors = dmp_sqf_list_include_in(self.to_dense(f), N, self.ngens-1, self.domain)
         return [(self.from_dense(g), k) for g, k in factors]
 
     def dup_gff_list(self, f):

--- a/diofant/polys/compatibility.py
+++ b/diofant/polys/compatibility.py
@@ -47,9 +47,8 @@ from .rootisolation import (dup_count_complex_roots, dup_count_real_roots,
                             dup_isolate_real_roots_list,
                             dup_isolate_real_roots_sqf, dup_refine_real_root,
                             dup_root_upper_bound, dup_sturm)
-from .sqfreetools import (dmp_sqf_list_in, dmp_sqf_list_include_in,
-                          dmp_sqf_norm, dmp_sqf_p_in, dmp_sqf_part_in,
-                          dup_gff_list)
+from .sqfreetools import (dmp_sqf_list_in, dmp_sqf_norm, dmp_sqf_p_in,
+                          dmp_sqf_part_in, dup_gff_list)
 
 
 __all__ = ('IPolys',)
@@ -546,10 +545,6 @@ class IPolys:
     def dmp_sqf_list_in(self, f, N):
         coeff, factors = dmp_sqf_list_in(self.to_dense(f), N, self.ngens-1, self.domain)
         return self.from_dense(coeff), [(self.from_dense(g), k) for g, k in factors]
-
-    def dmp_sqf_list_include_in(self, f, N):
-        factors = dmp_sqf_list_include_in(self.to_dense(f), N, self.ngens-1, self.domain)
-        return [(self.from_dense(g), k) for g, k in factors]
 
     def dup_gff_list(self, f):
         factors = dup_gff_list(self.to_dense(f), self.domain)

--- a/diofant/polys/compatibility.py
+++ b/diofant/polys/compatibility.py
@@ -539,13 +539,13 @@ class IPolys:
     def dmp_sqf_part(self, f):
         return self.from_dense(dmp_sqf_part(self.to_dense(f), self.ngens-1, self.domain))
 
-    def dmp_sqf_list(self, f, all=False):
-        coeff, factors = dmp_sqf_list(self.to_dense(f), self.ngens-1, self.domain, all=all)
+    def dmp_sqf_list(self, f):
+        coeff, factors = dmp_sqf_list(self.to_dense(f), self.ngens-1, self.domain)
         return coeff, [(self.from_dense(g), k) for g, k in factors]
 
-    def dmp_sqf_list_include(self, f, all=False):
-        factors = dmp_sqf_list_include(self.to_dense(f), self.ngens-1, self.domain, all=all)
-        return [ (self.from_dense(g), k) for g, k in factors ]
+    def dmp_sqf_list_include(self, f):
+        factors = dmp_sqf_list_include(self.to_dense(f), self.ngens-1, self.domain)
+        return [(self.from_dense(g), k) for g, k in factors]
 
     def dup_gff_list(self, f):
         factors = dup_gff_list(self.to_dense(f), self.domain)

--- a/diofant/polys/compatibility.py
+++ b/diofant/polys/compatibility.py
@@ -541,7 +541,7 @@ class IPolys:
 
     def dmp_sqf_list(self, f):
         coeff, factors = dmp_sqf_list(self.to_dense(f), self.ngens-1, self.domain)
-        return coeff, [(self.from_dense(g), k) for g, k in factors]
+        return self.from_dense(coeff), [(self.from_dense(g), k) for g, k in factors]
 
     def dmp_sqf_list_include(self, f):
         factors = dmp_sqf_list_include(self.to_dense(f), self.ngens-1, self.domain)

--- a/diofant/polys/factortools.py
+++ b/diofant/polys/factortools.py
@@ -27,7 +27,7 @@ from .polyconfig import query
 from .polyerrors import (CoercionFailed, DomainError, EvaluationFailed,
                          ExtraneousFactors)
 from .polyutils import _sort_factors
-from .sqfreetools import dmp_sqf_norm, dmp_sqf_p, dmp_sqf_part
+from .sqfreetools import dmp_sqf_norm, dmp_sqf_p_in, dmp_sqf_part_in
 
 
 def dmp_trial_division(f, factors, u, K):
@@ -364,7 +364,7 @@ def dup_cyclotomic_p(f, K, irreducible=False):
     if F == g and dup_cyclotomic_p(g, K):
         return True
 
-    G = dmp_sqf_part(F, 0, K)
+    G = dmp_sqf_part_in(F, [0], 0, K)
 
     if dup_sqr(G, K) == F and dup_cyclotomic_p(G, K):
         return True
@@ -523,7 +523,7 @@ def dup_zz_factor(f, K):
         if dup_zz_irreducible_p(g, K):
             return cont, [(g, 1)]
 
-    g = dmp_sqf_part(g, 0, K)
+    g = dmp_sqf_part_in(g, [0], 0, K)
     H = None
 
     if query('USE_CYCLOTOMIC_FACTOR'):
@@ -563,7 +563,7 @@ def dmp_zz_wang_test_points(f, T, ct, A, u, K):
 
     g = dmp_eval_tail(f, A, u, K)
 
-    if not dmp_sqf_p(g, 0, K):
+    if not dmp_sqf_p_in(g, [0], 0, K):
         raise EvaluationFailed('no luck')
 
     c, h = dmp_ground_primitive(g, 0, K)
@@ -997,7 +997,7 @@ def dmp_zz_factor(f, u, K):
     factors = []
 
     if dmp_degree(g, u) > 0:
-        g = dmp_sqf_part(g, u, K)
+        g = dmp_sqf_part_in(g, [0], u, K)
         H = dmp_zz_wang(g, u, K)
         factors = dmp_trial_division(f, H, u, K)
 
@@ -1018,7 +1018,7 @@ def dmp_ext_factor(f, u, K):
             factors.append(([factor], k))
 
     if dmp_degree(f, u) > 0:
-        sqf = dmp_sqf_part(f, u, K)
+        sqf = dmp_sqf_part_in(f, [0], u, K)
         s, g, r = dmp_sqf_norm(sqf, u, K)
 
         _, sqf_factors = dmp_factor_list(r, u, K.domain)

--- a/diofant/polys/galoistools.py
+++ b/diofant/polys/galoistools.py
@@ -1223,7 +1223,7 @@ def gf_sqf_part(f, p, K):
     return g
 
 
-def gf_sqf_list(f, p, K, all=False):
+def gf_sqf_list(f, p, K):
     """
     Return the square-free decomposition of a ``GF(p)[x]`` polynomial.
 
@@ -1297,9 +1297,6 @@ def gf_sqf_list(f, p, K, all=False):
             f, n = f[:d + 1], n*r
         else:
             break
-
-    if all:  # pragma: no cover
-        raise NotImplementedError("'all=True' is not supported yet")
 
     return lc, factors
 

--- a/diofant/polys/partfrac.py
+++ b/diofant/polys/partfrac.py
@@ -356,7 +356,7 @@ def apart_list_full_decomposition(P, Q, dummygen):
 
     partial = []
 
-    for d, n in Q.sqf_list_include(all=True):
+    for d, n in Q.sqf_list_include():
         b = d.as_expr()
         U += [ u.diff(x, n - 1) ]
 

--- a/diofant/polys/partfrac.py
+++ b/diofant/polys/partfrac.py
@@ -356,7 +356,7 @@ def apart_list_full_decomposition(P, Q, dummygen):
 
     partial = []
 
-    for d, n in Q.sqf_list_include():
+    for d, n in Q.sqf_list()[1]:
         b = d.as_expr()
         U += [ u.diff(x, n - 1) ]
 

--- a/diofant/polys/polyclasses.py
+++ b/diofant/polys/polyclasses.py
@@ -562,7 +562,7 @@ class DMP(CantSympify):
     def sqf_list(self):
         """Returns a list of square-free factors of ``self``. """
         coeff, factors = dmp_sqf_list(self.rep, self.lev, self.domain)
-        return coeff, [(self.per(g), k) for g, k in factors]
+        return self.per(coeff), [(self.per(g), k) for g, k in factors]
 
     def sqf_list_include(self):
         """Returns a list of square-free factors of ``self``. """

--- a/diofant/polys/polyclasses.py
+++ b/diofant/polys/polyclasses.py
@@ -559,14 +559,14 @@ class DMP(CantSympify):
         """Computes square-free part of ``self``. """
         return self.per(dmp_sqf_part(self.rep, self.lev, self.domain))
 
-    def sqf_list(self, all=False):
+    def sqf_list(self):
         """Returns a list of square-free factors of ``self``. """
-        coeff, factors = dmp_sqf_list(self.rep, self.lev, self.domain, all)
+        coeff, factors = dmp_sqf_list(self.rep, self.lev, self.domain)
         return coeff, [(self.per(g), k) for g, k in factors]
 
-    def sqf_list_include(self, all=False):
+    def sqf_list_include(self):
         """Returns a list of square-free factors of ``self``. """
-        factors = dmp_sqf_list_include(self.rep, self.lev, self.domain, all)
+        factors = dmp_sqf_list_include(self.rep, self.lev, self.domain)
         return [(self.per(g), k) for g, k in factors]
 
     def factor_list(self):

--- a/diofant/polys/polyclasses.py
+++ b/diofant/polys/polyclasses.py
@@ -28,8 +28,9 @@ from .rootisolation import (dup_count_complex_roots, dup_count_real_roots,
                             dup_isolate_all_roots, dup_isolate_all_roots_sqf,
                             dup_isolate_real_roots, dup_isolate_real_roots_sqf,
                             dup_refine_real_root, dup_sturm)
-from .sqfreetools import (dmp_sqf_list, dmp_sqf_list_include, dmp_sqf_norm,
-                          dmp_sqf_p, dmp_sqf_part, dup_gff_list)
+from .sqfreetools import (dmp_sqf_list_in, dmp_sqf_list_include_in,
+                          dmp_sqf_norm, dmp_sqf_p_in, dmp_sqf_part_in,
+                          dup_gff_list)
 
 
 class DMP(CantSympify):
@@ -557,16 +558,16 @@ class DMP(CantSympify):
 
     def sqf_part(self):
         """Computes square-free part of ``self``. """
-        return self.per(dmp_sqf_part(self.rep, self.lev, self.domain))
+        return self.per(dmp_sqf_part_in(self.rep, list(range(self.lev + 1)), self.lev, self.domain))
 
     def sqf_list(self):
         """Returns a list of square-free factors of ``self``. """
-        coeff, factors = dmp_sqf_list(self.rep, self.lev, self.domain)
+        coeff, factors = dmp_sqf_list_in(self.rep, list(range(self.lev + 1)), self.lev, self.domain)
         return self.per(coeff), [(self.per(g), k) for g, k in factors]
 
     def sqf_list_include(self):
         """Returns a list of square-free factors of ``self``. """
-        factors = dmp_sqf_list_include(self.rep, self.lev, self.domain)
+        factors = dmp_sqf_list_include_in(self.rep, list(range(self.lev + 1)), self.lev, self.domain)
         return [(self.per(g), k) for g, k in factors]
 
     def factor_list(self):
@@ -636,7 +637,7 @@ class DMP(CantSympify):
     @property
     def is_squarefree(self):
         """Returns ``True`` if ``self`` is a square-free polynomial. """
-        return dmp_sqf_p(self.rep, self.lev, self.domain)
+        return dmp_sqf_p_in(self.rep, list(range(self.lev + 1)), self.lev, self.domain)
 
     @property
     def is_monic(self):

--- a/diofant/polys/polyclasses.py
+++ b/diofant/polys/polyclasses.py
@@ -28,9 +28,8 @@ from .rootisolation import (dup_count_complex_roots, dup_count_real_roots,
                             dup_isolate_all_roots, dup_isolate_all_roots_sqf,
                             dup_isolate_real_roots, dup_isolate_real_roots_sqf,
                             dup_refine_real_root, dup_sturm)
-from .sqfreetools import (dmp_sqf_list_in, dmp_sqf_list_include_in,
-                          dmp_sqf_norm, dmp_sqf_p_in, dmp_sqf_part_in,
-                          dup_gff_list)
+from .sqfreetools import (dmp_sqf_list_in, dmp_sqf_norm, dmp_sqf_p_in,
+                          dmp_sqf_part_in, dup_gff_list)
 
 
 class DMP(CantSympify):
@@ -564,11 +563,6 @@ class DMP(CantSympify):
         """Returns a list of square-free factors of ``self``. """
         coeff, factors = dmp_sqf_list_in(self.rep, list(range(self.lev + 1)), self.lev, self.domain)
         return self.per(coeff), [(self.per(g), k) for g, k in factors]
-
-    def sqf_list_include(self):
-        """Returns a list of square-free factors of ``self``. """
-        factors = dmp_sqf_list_include_in(self.rep, list(range(self.lev + 1)), self.lev, self.domain)
-        return [(self.per(g), k) for g, k in factors]
 
     def factor_list(self):
         """Returns a list of irreducible factors of ``self``. """

--- a/diofant/polys/polytools.py
+++ b/diofant/polys/polytools.py
@@ -2443,15 +2443,15 @@ class Poly(Expr):
         >>> f = 2*x**5 + 16*x**4 + 50*x**3 + 76*x**2 + 56*x + 16
 
         >>> Poly(f).sqf_list()
-        (2, [(Poly(x + 1, x, domain='ZZ'), 2),
-             (Poly(x + 2, x, domain='ZZ'), 3)])
+        (Poly(2, x, domain='ZZ'), [(Poly(x + 1, x, domain='ZZ'), 2),
+                                   (Poly(x + 2, x, domain='ZZ'), 3)])
         """
         if hasattr(self.rep, 'sqf_list'):
             coeff, factors = self.rep.sqf_list()
         else:  # pragma: no cover
             raise OperationNotSupported(self, 'sqf_list')
 
-        return (self.rep.domain.to_expr(coeff),
+        return (self.per(coeff),
                 [(self.per(g), k) for g, k in factors])
 
     def sqf_list_include(self):
@@ -4734,6 +4734,7 @@ def _symbolic_factor_list(expr, opt, method):
             func = getattr(poly, method + '_list')
 
             _coeff, _factors = func()
+            _coeff = _coeff.as_expr()
             if _coeff is not S.One:
                 if exp.is_Integer:
                     coeff *= _coeff**exp

--- a/diofant/polys/polytools.py
+++ b/diofant/polys/polytools.py
@@ -2454,29 +2454,6 @@ class Poly(Expr):
         return (self.per(coeff),
                 [(self.per(g), k) for g, k in factors])
 
-    def sqf_list_include(self):
-        """
-        Returns a list of square-free factors of ``self``.
-
-        Examples
-        ========
-
-        >>> f = expand(2*(x + 1)**3*x**4)
-        >>> f
-        2*x**7 + 6*x**6 + 6*x**5 + 2*x**4
-
-        >>> Poly(f).sqf_list_include()
-        [(Poly(2, x, domain='ZZ'), 1),
-         (Poly(x + 1, x, domain='ZZ'), 3),
-         (Poly(x, x, domain='ZZ'), 4)]
-        """
-        if hasattr(self.rep, 'sqf_list_include'):
-            factors = self.rep.sqf_list_include()
-        else:  # pragma: no cover
-            raise OperationNotSupported(self, 'sqf_list_include')
-
-        return [(self.per(g), k) for g, k in factors]
-
     def factor_list(self):
         """
         Returns a list of irreducible factors of ``self``.

--- a/diofant/polys/polytools.py
+++ b/diofant/polys/polytools.py
@@ -2433,7 +2433,7 @@ class Poly(Expr):
 
         return self.per(result)
 
-    def sqf_list(self, all=False):
+    def sqf_list(self):
         """
         Returns a list of square-free factors of ``self``.
 
@@ -2445,21 +2445,16 @@ class Poly(Expr):
         >>> Poly(f).sqf_list()
         (2, [(Poly(x + 1, x, domain='ZZ'), 2),
              (Poly(x + 2, x, domain='ZZ'), 3)])
-
-        >>> Poly(f).sqf_list(all=True)
-        (2, [(Poly(1, x, domain='ZZ'), 1),
-             (Poly(x + 1, x, domain='ZZ'), 2),
-             (Poly(x + 2, x, domain='ZZ'), 3)])
         """
         if hasattr(self.rep, 'sqf_list'):
-            coeff, factors = self.rep.sqf_list(all)
+            coeff, factors = self.rep.sqf_list()
         else:  # pragma: no cover
             raise OperationNotSupported(self, 'sqf_list')
 
         return (self.rep.domain.to_expr(coeff),
                 [(self.per(g), k) for g, k in factors])
 
-    def sqf_list_include(self, all=False):
+    def sqf_list_include(self):
         """
         Returns a list of square-free factors of ``self``.
 
@@ -2474,15 +2469,9 @@ class Poly(Expr):
         [(Poly(2, x, domain='ZZ'), 1),
          (Poly(x + 1, x, domain='ZZ'), 3),
          (Poly(x, x, domain='ZZ'), 4)]
-
-        >>> Poly(f).sqf_list_include(all=True)
-        [(Poly(2, x, domain='ZZ'), 1),
-         (Poly(1, x, domain='ZZ'), 2),
-         (Poly(x + 1, x, domain='ZZ'), 3),
-         (Poly(x, x, domain='ZZ'), 4)]
         """
         if hasattr(self.rep, 'sqf_list_include'):
-            factors = self.rep.sqf_list_include(all)
+            factors = self.rep.sqf_list_include()
         else:  # pragma: no cover
             raise OperationNotSupported(self, 'sqf_list_include')
 

--- a/diofant/polys/rings.py
+++ b/diofant/polys/rings.py
@@ -792,10 +792,7 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
 
     @property
     def is_squarefree(self):
-        if self.is_zero:
-            return True
-        else:
-            return not self.gcd(self.diff(0)).degree(0)
+        return self.ring.dmp_sqf_p_in(self, list(range(self.ring.ngens)))
 
     @property
     def is_irreducible(self):
@@ -2285,10 +2282,10 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
         return self.ring.dmp_sqf_norm(self)
 
     def sqf_part(self):
-        return self.ring.dmp_sqf_part(self)
+        return self.ring.dmp_sqf_part_in(self, list(range(self.ring.ngens)))
 
     def sqf_list(self):
-        return self.ring.dmp_sqf_list(self)
+        return self.ring.dmp_sqf_list_in(self, list(range(self.ring.ngens)))
 
     def factor_list(self):
         return self.ring.dmp_factor_list(self)

--- a/diofant/polys/rings.py
+++ b/diofant/polys/rings.py
@@ -2287,8 +2287,8 @@ class PolyElement(DomainElement, DefaultPrinting, CantSympify, dict):
     def sqf_part(self):
         return self.ring.dmp_sqf_part(self)
 
-    def sqf_list(self, all=False):
-        return self.ring.dmp_sqf_list(self, all=all)
+    def sqf_list(self):
+        return self.ring.dmp_sqf_list(self)
 
     def factor_list(self):
         return self.ring.dmp_factor_list(self)

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -11,7 +11,7 @@ from .densetools import (dmp_clear_denoms, dmp_compose, dmp_eval, dmp_eval_in,
 from .euclidtools import dmp_gcd, dmp_resultant
 from .factortools import dmp_factor_list
 from .polyerrors import DomainError, RefinementFailed
-from .sqfreetools import dmp_sqf_list, dmp_sqf_part
+from .sqfreetools import dmp_sqf_list_in, dmp_sqf_part_in
 
 
 def dup_sturm(f, K):
@@ -36,7 +36,7 @@ def dup_sturm(f, K):
     if not K.has_Field:
         raise DomainError("can't compute Sturm sequence over %s" % K)
 
-    f = dmp_sqf_part(f, 0, K)
+    f = dmp_sqf_part_in(f, [0], 0, K)
 
     sturm = [f, dup_diff(f, 1, K)]
 
@@ -457,7 +457,7 @@ def dup_isolate_real_roots(f, K, eps=None, inf=None, sup=None, fast=False):
     f = dmp_convert(f, 0, R, K)
     f = dmp_clear_denoms(f, 0, K)[1]
 
-    _, factors = dmp_sqf_list(f, 0, K)
+    _, factors = dmp_sqf_list_in(f, [0], 0, K)
 
     if len(factors) == 1:
         (f, k), = factors
@@ -1574,7 +1574,7 @@ def dup_isolate_all_roots(f, K, eps=None, inf=None, sup=None, fast=False):
     if not K.is_IntegerRing and not K.is_RationalField:
         raise DomainError("isolation of real and complex roots is not supported over %s" % K)
 
-    _, factors = dmp_sqf_list(f, 0, K)
+    _, factors = dmp_sqf_list_in(f, [0], 0, K)
 
     if len(factors) == 1:
         (f, k), = factors

--- a/diofant/polys/sqfreetools.py
+++ b/diofant/polys/sqfreetools.py
@@ -1,11 +1,12 @@
 """Square-free decomposition algorithms and related tools. """
 
-from .densearith import dmp_mul_ground, dmp_neg, dmp_quo, dmp_sub, dup_mul
+from .densearith import (dmp_mul, dmp_mul_ground, dmp_neg, dmp_quo, dmp_sub,
+                         dup_mul)
 from .densebasic import (dmp_convert, dmp_degree, dmp_ground, dmp_ground_LC,
                          dmp_inject, dmp_raise, dmp_zero_p)
 from .densetools import (dmp_compose, dmp_diff, dmp_ground_monic,
                          dmp_ground_primitive, dup_shift)
-from .euclidtools import dmp_gcd, dmp_inner_gcd, dmp_resultant
+from .euclidtools import dmp_gcd, dmp_inner_gcd, dmp_primitive, dmp_resultant
 from .galoistools import gf_sqf_list, gf_sqf_part
 from .polyerrors import DomainError
 
@@ -125,7 +126,7 @@ def dmp_gf_sqf_list(f, u, K):
         for i, (f, k) in enumerate(factors):
             factors[i] = (dmp_convert(f, u, K.domain, K), k)
 
-        return K.convert(coeff, K.domain), factors
+        return [K.convert(coeff, K.domain)], factors
 
     else:
         raise NotImplementedError('multivariate polynomials over finite fields')
@@ -157,6 +158,12 @@ def dmp_sqf_list(f, u, K):
         if K.is_negative(dmp_ground_LC(f, u, K)):
             f = dmp_neg(f, u, K)
             coeff = -coeff
+
+    if u:
+        c, f = dmp_primitive(f, u, K)
+        coeff = dmp_mul_ground([c], coeff, u, K)
+    else:
+        coeff = dmp_ground(coeff, u)
 
     if dmp_degree(f, u) <= 0:
         return coeff, []
@@ -201,11 +208,10 @@ def dmp_sqf_list_include(f, u, K):
     coeff, factors = dmp_sqf_list(f, u, K)
 
     if factors and factors[0][1] == 1:
-        g = dmp_mul_ground(factors[0][0], coeff, u, K)
+        g = dmp_mul(factors[0][0], coeff, u, K)
         return [(g, 1)] + factors[1:]
     else:
-        g = dmp_ground(coeff, u)
-        return [(g, 1)] + factors
+        return [(coeff, 1)] + factors
 
 
 def dup_gff_list(f, K):

--- a/diofant/polys/sqfreetools.py
+++ b/diofant/polys/sqfreetools.py
@@ -1,7 +1,7 @@
 """Square-free decomposition algorithms and related tools. """
 
-from .densearith import (dmp_mul, dmp_mul_ground, dmp_neg, dmp_pow, dmp_quo,
-                         dmp_sub, dup_mul)
+from .densearith import (dmp_mul_ground, dmp_neg, dmp_pow, dmp_quo, dmp_sub,
+                         dup_mul)
 from .densebasic import (dmp_convert, dmp_degree, dmp_degree_in, dmp_ground_LC,
                          dmp_inject, dmp_one_p, dmp_raise, dmp_zero_p)
 from .densetools import (dmp_compose, dmp_diff_in, dmp_ground_monic,
@@ -193,29 +193,6 @@ def dmp_sqf_list_in(f, N, u, K):
         count += 1
 
     return coeff, result
-
-
-def dmp_sqf_list_include_in(f, N, u, K):
-    """
-    Return square-free decomposition of a polynomial in ``K[x]``.
-
-    Examples
-    ========
-
-    >>> R, x, y = ring("x y", ZZ)
-
-    >>> f = x**5 + 2*x**4*y + x**3*y**2
-
-    >>> R.dmp_sqf_list_include_in(f, [0, 1])
-    [(1, 1), (x + y, 2), (x, 3)]
-    """
-    coeff, factors = dmp_sqf_list_in(f, N, u, K)
-
-    if factors and factors[0][1] == 1:
-        g = dmp_mul(factors[0][0], coeff, u, K)
-        return [(g, 1)] + factors[1:]
-    else:
-        return [(coeff, 1)] + factors
 
 
 def dup_gff_list(f, K):

--- a/diofant/polys/sqfreetools.py
+++ b/diofant/polys/sqfreetools.py
@@ -115,12 +115,12 @@ def dmp_sqf_part(f, u, K):
         return dmp_ground_primitive(sqf, u, K)[1]
 
 
-def dmp_gf_sqf_list(f, u, K, all=False):
+def dmp_gf_sqf_list(f, u, K):
     """Compute square-free decomposition of ``f`` in ``GF(p)[X]``. """
     if not u:
         f = dmp_convert(f, u, K, K.domain)
 
-        coeff, factors = gf_sqf_list(f, K.mod, K.domain, all=all)
+        coeff, factors = gf_sqf_list(f, K.mod, K.domain)
 
         for i, (f, k) in enumerate(factors):
             factors[i] = (dmp_convert(f, u, K.domain, K), k)
@@ -131,7 +131,7 @@ def dmp_gf_sqf_list(f, u, K, all=False):
         raise NotImplementedError('multivariate polynomials over finite fields')
 
 
-def dmp_sqf_list(f, u, K, all=False):
+def dmp_sqf_list(f, u, K):
     """
     Return square-free decomposition of a polynomial in ``K[X]``.
 
@@ -144,11 +144,9 @@ def dmp_sqf_list(f, u, K, all=False):
 
     >>> R.dmp_sqf_list(f)
     (1, [(x + y, 2), (x, 3)])
-    >>> R.dmp_sqf_list(f, all=True)
-    (1, [(1, 1), (x + y, 2), (x, 3)])
     """
     if K.is_FiniteField:
-        return dmp_gf_sqf_list(f, u, K, all=all)
+        return dmp_gf_sqf_list(f, u, K)
 
     if K.has_Field:
         coeff = dmp_ground_LC(f, u, K)
@@ -178,7 +176,7 @@ def dmp_sqf_list(f, u, K, all=False):
 
         g, p, q = dmp_inner_gcd(p, h, u, K)
 
-        if all or dmp_degree(g, u) > 0:
+        if dmp_degree(g, u) > 0:
             result.append((g, i))
 
         i += 1
@@ -186,7 +184,7 @@ def dmp_sqf_list(f, u, K, all=False):
     return coeff, result
 
 
-def dmp_sqf_list_include(f, u, K, all=False):
+def dmp_sqf_list_include(f, u, K):
     """
     Return square-free decomposition of a polynomial in ``K[x]``.
 
@@ -199,11 +197,8 @@ def dmp_sqf_list_include(f, u, K, all=False):
 
     >>> R.dmp_sqf_list_include(f)
     [(1, 1), (x + y, 2), (x, 3)]
-    >>> R.dmp_sqf_list_include(f, all=True)
-    [(1, 1), (x + y, 2), (x, 3)]
-
     """
-    coeff, factors = dmp_sqf_list(f, u, K, all=all)
+    coeff, factors = dmp_sqf_list(f, u, K)
 
     if factors and factors[0][1] == 1:
         g = dmp_mul_ground(factors[0][0], coeff, u, K)

--- a/diofant/polys/tests/test_polyclasses.py
+++ b/diofant/polys/tests/test_polyclasses.py
@@ -216,7 +216,7 @@ def test_DMP_functionality():
     f = DMP(f_4, ZZ)
 
     assert f.sqf_part() == -f
-    assert f.sqf_list() == (ZZ(-1), [(-f, 1)])
+    assert f.sqf_list() == (DMP([[[-1]]], ZZ), [(-f, 1)])
 
     f = DMP([[-1], [], [], [5]], ZZ)
     g = DMP([[3, 1], [], []], ZZ)

--- a/diofant/polys/tests/test_polytools.py
+++ b/diofant/polys/tests/test_polytools.py
@@ -2261,9 +2261,6 @@ def test_sqf():
     assert sqf_list(F, polys=False) == (1, [(g, 1), (h, 2)])
 
     pytest.raises(PolynomialError, lambda: sqf_list([1, 2]))
-
-    assert F.sqf_list_include() == [(G, 1), (H, 2)]
-
     pytest.raises(ComputationFailed, lambda: sqf_part(4))
 
     assert sqf(1) == 1

--- a/diofant/polys/tests/test_rings.py
+++ b/diofant/polys/tests/test_rings.py
@@ -1414,6 +1414,13 @@ def test_PolyElement_is_():
     assert f.is_nonnegative is True
     assert f.is_nonpositive is False
 
+    # issue diofant/diofant#714
+    R, x, y, z = ring('x y z', ZZ)
+    f = (x - y)*(z - 1)**2
+    assert f.is_squarefree is False
+    assert ((x - y)**2*(z - 1)).is_squarefree is False
+    assert ((x - y)*(z - 1)).is_squarefree is True
+
 
 def test_PolyElement_drop():
     R,  x, y, z = ring("x,y,z", ZZ)
@@ -1555,7 +1562,20 @@ def test_PolyElement_sqf_norm():
 
 
 def test_PolyElement_sqf_list():
-    _, x = ring("x", ZZ)
+    R, x = ring("x", ZZ)
+
+    assert R.zero.sqf_list() == (0, [])
+    assert R.one.sqf_list() == (1, [])
+    assert x.sqf_list() == (1, [(x, 1)])
+    assert (2*x**2).sqf_list() == (2, [(x, 2)])
+    assert (3*x**3).sqf_list() == (3, [(x, 3)])
+    assert (-2*x + 1).sqf_list() == (-1, [(2*x - 1, 1)])
+
+    assert (-x**5 + x**4 + x - 1).sqf_list() == (-1, [(x**3 + x**2 + x + 1, 1),
+                                                      (x - 1, 2)])
+    assert (x**8 + 6*x**6 + 12*x**4 + 8*x**2).sqf_list() == (1, [(x, 2),
+                                                                 (x**2 + 2, 3)])
+    assert (2*x**2 + 4*x + 2).sqf_list() == (2, [(x + 1, 2)])
 
     f = x**5 - x**3 - x**2 + 1
     g = x**3 + 2*x**2 + 2*x + 1
@@ -1564,6 +1584,37 @@ def test_PolyElement_sqf_list():
 
     assert f.sqf_part() == p
     assert f.sqf_list() == (1, [(g, 1), (h, 2)])
+
+    f = -x**5 + x**4 + x - 1
+
+    assert f.sqf_list() == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
+
+    f = 2*x**5 + 16*x**4 + 50*x**3 + 76*x**2 + 56*x + 16
+
+    assert f.sqf_list() == (2, [(x + 1, 2), (x + 2, 3)])
+
+    _, x, y = ring("x,y", ZZ)
+    f = -x**5 + x**4 + x - 1
+
+    assert f.sqf_list() == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
+
+    _, x = ring("x", QQ)
+
+    assert (2*x**2 + 4*x + 2).sqf_list() == (2, [(x + 1, 2)])
+
+    f = (2*x - 1)*(3*x**2 + 4)
+    assert f.sqf_part() == (x - QQ(1, 2))*(x**2 + QQ(4, 3))
+    assert f.sqf_list() == (6, [(x**3 - x**2/2 + 4*x/3 - QQ(2, 3), 1)])
+
+    # issue diofant/diofant#714
+
+    _, x, y, z = ring('x y z', ZZ)
+
+    f = (x - y)*(z - 1)**2
+    assert f.sqf_list() == (1, [(x - y, 1), (z - 1, 2)])
+
+    f = (x - y)**2*(z - 1)**3
+    assert f.sqf_list() == (1, [(x - y, 2), (z - 1, 3)])
 
 
 def test_PolyElement_factor_list():

--- a/diofant/polys/tests/test_rootisolation.py
+++ b/diofant/polys/tests/test_rootisolation.py
@@ -362,7 +362,7 @@ def test_dup_isolate_real_roots():
 
     f = 16*x**14 - 96*x**13 + 24*x**12 + 936*x**11 - 1599*x**10 - 2880*x**9 + 9196*x**8 \
         + 552*x**7 - 21831*x**6 + 13968*x**5 + 21690*x**4 - 26784*x**3 - 2916*x**2 + 15552*x - 5832
-    g = R.dmp_sqf_part(f)
+    g = R.dmp_sqf_part_in(f, [0])
 
     assert R.dup_isolate_real_roots(f) == \
         [((-2, -QQ(3, 2)), 2), ((-QQ(3, 2), -QQ(1, 1)), 3), ((1, QQ(3, 2)), 3),

--- a/diofant/polys/tests/test_sqfreetools.py
+++ b/diofant/polys/tests/test_sqfreetools.py
@@ -18,52 +18,52 @@ f_0, f_1, f_2, f_3, f_4, f_5, f_6 = f_polys()
 def test_dup_sqf():
     R, x = ring("x", ZZ)
 
-    assert R.dmp_sqf_part(0) == 0
+    assert R.dmp_sqf_part_in(0, [0]) == 0
     assert R(0).is_squarefree is True
 
-    assert R.dmp_sqf_part(7) == 1
+    assert R.dmp_sqf_part_in(7, [0]) == 1
     assert R(7).is_squarefree is True
 
-    assert R.dmp_sqf_part(2*x + 2) == x + 1
+    assert R.dmp_sqf_part_in(2*x + 2, [0]) == x + 1
     assert (2*x + 2).is_squarefree is True
 
-    assert R.dmp_sqf_part(x**3 + x + 1) == x**3 + x + 1
+    assert R.dmp_sqf_part_in(x**3 + x + 1, [0]) == x**3 + x + 1
     assert (x**3 + x + 1).is_squarefree is True
 
-    assert R.dmp_sqf_part(-x**3 + x + 1) == x**3 - x - 1
+    assert R.dmp_sqf_part_in(-x**3 + x + 1, [0]) == x**3 - x - 1
     assert (-x**3 + x + 1).is_squarefree is True
 
-    assert R.dmp_sqf_part(2*x**3 + 3*x**2) == 2*x**2 + 3*x
+    assert R.dmp_sqf_part_in(2*x**3 + 3*x**2, [0]) == 2*x**2 + 3*x
     assert (2*x**3 + 3*x**2).is_squarefree is False
 
-    assert R.dmp_sqf_part(-2*x**3 + 3*x**2) == 2*x**2 - 3*x
+    assert R.dmp_sqf_part_in(-2*x**3 + 3*x**2, [0]) == 2*x**2 - 3*x
     assert (-2*x**3 + 3*x**2).is_squarefree is False
 
-    assert R.dmp_sqf_part(x**3 - 3*x - 2) == x**2 - x - 2
+    assert R.dmp_sqf_part_in(x**3 - 3*x - 2, [0]) == x**2 - x - 2
     assert (x**3 - 3*x - 2).is_squarefree is False
 
-    assert R.dmp_sqf_list(0) == (0, [])
-    assert R.dmp_sqf_list(1) == (1, [])
+    assert R.dmp_sqf_list_in(0, [0]) == (0, [])
+    assert R.dmp_sqf_list_in(1, [0]) == (1, [])
 
-    assert R.dmp_sqf_list(x) == (1, [(x, 1)])
-    assert R.dmp_sqf_list(2*x**2) == (2, [(x, 2)])
-    assert R.dmp_sqf_list(3*x**3) == (3, [(x, 3)])
+    assert R.dmp_sqf_list_in(x, [0]) == (1, [(x, 1)])
+    assert R.dmp_sqf_list_in(2*x**2, [0]) == (2, [(x, 2)])
+    assert R.dmp_sqf_list_in(3*x**3, [0]) == (3, [(x, 3)])
 
-    assert R.dmp_sqf_list(-x**5 + x**4 + x - 1) == \
+    assert R.dmp_sqf_list_in(-x**5 + x**4 + x - 1, [0]) == \
         (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
-    assert R.dmp_sqf_list(x**8 + 6*x**6 + 12*x**4 + 8*x**2) == \
+    assert R.dmp_sqf_list_in(x**8 + 6*x**6 + 12*x**4 + 8*x**2, [0]) == \
         ( 1, [(x, 2), (x**2 + 2, 3)])
 
-    assert R.dmp_sqf_list(2*x**2 + 4*x + 2) == (2, [(x + 1, 2)])
+    assert R.dmp_sqf_list_in(2*x**2 + 4*x + 2, [0]) == (2, [(x + 1, 2)])
 
     R, x = ring("x", QQ)
-    assert R.dmp_sqf_list(2*x**2 + 4*x + 2) == (2, [(x + 1, 2)])
+    assert R.dmp_sqf_list_in(2*x**2 + 4*x + 2, [0]) == (2, [(x + 1, 2)])
 
     R, x = ring("x", FF(2))
-    assert R.dmp_sqf_list(x**2 + 1) == (1, [(x + 1, 2)])
+    assert R.dmp_sqf_list_in(x**2 + 1, [0]) == (1, [(x + 1, 2)])
 
     R, x = ring("x", FF(3))
-    assert R.dmp_sqf_list(x**10 + 2*x**7 + 2*x**4 + x) == \
+    assert R.dmp_sqf_list_in(x**10 + 2*x**7 + 2*x**4 + x, [0]) == \
         (1, [(x, 1),
              (x + 1, 3),
              (x + 2, 6)])
@@ -74,8 +74,8 @@ def test_dup_sqf():
     f = x**3 + 1
     g = y**3 + 1
 
-    assert R1.dmp_sqf_part(f) == f
-    assert R2.dmp_sqf_part(g) == y + 1
+    assert R1.dmp_sqf_part_in(f, [0]) == f
+    assert R2.dmp_sqf_part_in(g, [0]) == y + 1
 
     assert f.is_squarefree is True
     assert g.is_squarefree is False
@@ -89,13 +89,13 @@ def test_dup_sqf():
     res = R.dmp_resultant(f, g)
     h = (4*y**2 + 1).drop(x)
 
-    assert R.drop(x).dmp_sqf_list(res) == (45796, [(h, 3)])
+    assert R.drop(x).dmp_sqf_list_in(res, [0]) == (45796, [(h, 3)])
 
     pytest.raises(DomainError, lambda: R.dmp_sqf_norm(x**2 - 1))
 
     Rt, t = ring("t", ZZ)
     R, x = ring("x", Rt)
-    assert R.dmp_sqf_list_include(t**3*x**2) == [(t**3, 1), (x, 2)]
+    assert R.dmp_sqf_list_include_in(t**3*x**2, [0]) == [(t**3, 1), (x, 2)]
 
     K = QQ.algebraic_field(sqrt(3))
     R, x = ring("x", K)
@@ -105,14 +105,14 @@ def test_dup_sqf():
 
 def test_dmp_sqf():
     R, x, y = ring("x,y", ZZ)
-    assert R.dmp_sqf_part(0) == 0
+    assert R.dmp_sqf_part_in(0, [0, 1]) == 0
     assert R(0).is_squarefree is True
 
-    assert R.dmp_sqf_part(7) == 1
+    assert R.dmp_sqf_part_in(7, [0, 1]) == 1
     assert R(7).is_squarefree is True
 
-    assert R.dmp_sqf_list(3) == (3, [])
-    assert R.dmp_sqf_list_include(3) == [(3, 1)]
+    assert R.dmp_sqf_list_in(3, [0, 1]) == (3, [])
+    assert R.dmp_sqf_list_include_in(3, [0, 1]) == [(3, 1)]
 
     R, x, y, z = ring("x,y,z", ZZ)
     assert f_0.is_squarefree is True
@@ -127,44 +127,44 @@ def test_dmp_sqf():
     assert (f_5**2).is_squarefree is False
 
     assert f_4.is_squarefree is True
-    assert R.dmp_sqf_part(f_4) == -f_4
+    assert R.dmp_sqf_part_in(f_4, [0, 1, 2]) == -f_4
 
-    assert R.dmp_sqf_part(f_5) == x + y - z
+    assert R.dmp_sqf_part_in(f_5, [0, 1, 2]) == x + y - z
 
     R, x, y, z, t = ring("x,y,z,t", ZZ)
     assert f_6.is_squarefree is True
-    assert R.dmp_sqf_part(f_6) == f_6
+    assert R.dmp_sqf_part_in(f_6, [0, 1, 2, 3]) == f_6
 
     R, x = ring("x", ZZ)
     f = -x**5 + x**4 + x - 1
 
-    assert R.dmp_sqf_list(f) == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
-    assert R.dmp_sqf_list_include(f) == [(-x**3 - x**2 - x - 1, 1), (x - 1, 2)]
+    assert R.dmp_sqf_list_in(f, [0]) == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
+    assert R.dmp_sqf_list_include_in(f, [0]) == [(-x**3 - x**2 - x - 1, 1), (x - 1, 2)]
 
     f = 2*x**5 + 16*x**4 + 50*x**3 + 76*x**2 + 56*x + 16
 
-    assert R.dmp_sqf_list(f) == (2, [(x + 1, 2), (x + 2, 3)])
-    assert R.dmp_sqf_list_include(f) == [(2, 1), (x + 1, 2), (x + 2, 3)]
+    assert R.dmp_sqf_list_in(f, [0]) == (2, [(x + 1, 2), (x + 2, 3)])
+    assert R.dmp_sqf_list_include_in(f, [0]) == [(2, 1), (x + 1, 2), (x + 2, 3)]
 
     R, x, y = ring("x,y", ZZ)
     f = -x**5 + x**4 + x - 1
 
-    assert R.dmp_sqf_list(f) == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
-    assert R.dmp_sqf_list_include(f) == [(-x**3 - x**2 - x - 1, 1), (x - 1, 2)]
+    assert R.dmp_sqf_list_in(f, [0, 1]) == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
+    assert R.dmp_sqf_list_include_in(f, [0, 1]) == [(-x**3 - x**2 - x - 1, 1), (x - 1, 2)]
 
     pytest.raises(DomainError, lambda: R.dmp_sqf_norm(x**2 + y**2))
 
     f = -x**2 + 2*x - 1
-    assert R.dmp_sqf_list_include(f) == [(-1, 1), (x - 1, 2)]
+    assert R.dmp_sqf_list_include_in(f, [0, 1]) == [(-1, 1), (x - 1, 2)]
 
     R, x, y = ring("x,y", FF(2))
-    pytest.raises(NotImplementedError, lambda: R.dmp_sqf_list(y**2 + 1))
+    pytest.raises(NotImplementedError, lambda: R.dmp_sqf_list_in(y**2 + 1, [0, 1]))
     pytest.raises(NotImplementedError,
-                  lambda: R.dmp_sqf_part(x**3 + 2*x**2*y + x*y**2))
+                  lambda: R.dmp_sqf_part_in(x**3 + 2*x**2*y + x*y**2, [0]))
 
     R, x, y = ring("x,y", QQ.algebraic_field(I))
-    assert R.dmp_sqf_list(x**2 + 2*I*x - 1) == (R.one.to_dense()[0][0],
-                                                [(x + I, 2)])
+    assert R.dmp_sqf_list_in(x**2 + 2*I*x - 1, [0, 1]) == (R.one.to_dense()[0][0],
+                                                           [(x + I, 2)])
 
 
 def test_dup_gff_list():
@@ -177,3 +177,17 @@ def test_dup_gff_list():
     assert R.dup_gff_list(g) == [(x**2 - 5*x + 4, 1), (x**2 - 5*x + 4, 2), (x, 3)]
 
     pytest.raises(ValueError, lambda: R.dup_gff_list(0))
+
+
+def test_diofantissue_714():
+    R, x, y, z = ring('x y z', ZZ)
+
+    f = (x - y)*(z - 1)**2
+
+    assert f.is_squarefree is False
+
+    assert R.dmp_sqf_part_in(f, [0]) == R.dmp_sqf_part_in(f, [0, 1]) == x - y
+    assert R.dmp_sqf_part_in(f, [0, 1, 2]) == f.sqf_part() == (x - y)*(z - 1)
+
+    assert R.dmp_sqf_list_in(f, [0]) == R.dmp_sqf_list_in(f, [0, 1]) == ((z - 1)**2, [(x - y, 1)])
+    assert f.sqf_list() == R.dmp_sqf_list_in(f, [0, 1, 2]) == (1, [(x - y, 1), (z - 1, 2)])

--- a/diofant/polys/tests/test_sqfreetools.py
+++ b/diofant/polys/tests/test_sqfreetools.py
@@ -93,10 +93,6 @@ def test_dup_sqf():
 
     pytest.raises(DomainError, lambda: R.dmp_sqf_norm(x**2 - 1))
 
-    Rt, t = ring("t", ZZ)
-    R, x = ring("x", Rt)
-    assert R.dmp_sqf_list_include_in(t**3*x**2, [0]) == [(t**3, 1), (x, 2)]
-
     K = QQ.algebraic_field(sqrt(3))
     R, x = ring("x", K)
     _, X = ring("x", QQ)
@@ -112,7 +108,6 @@ def test_dmp_sqf():
     assert R(7).is_squarefree is True
 
     assert R.dmp_sqf_list_in(3, [0, 1]) == (3, [])
-    assert R.dmp_sqf_list_include_in(3, [0, 1]) == [(3, 1)]
 
     R, x, y, z = ring("x,y,z", ZZ)
     assert f_0.is_squarefree is True
@@ -139,23 +134,19 @@ def test_dmp_sqf():
     f = -x**5 + x**4 + x - 1
 
     assert R.dmp_sqf_list_in(f, [0]) == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
-    assert R.dmp_sqf_list_include_in(f, [0]) == [(-x**3 - x**2 - x - 1, 1), (x - 1, 2)]
 
     f = 2*x**5 + 16*x**4 + 50*x**3 + 76*x**2 + 56*x + 16
 
     assert R.dmp_sqf_list_in(f, [0]) == (2, [(x + 1, 2), (x + 2, 3)])
-    assert R.dmp_sqf_list_include_in(f, [0]) == [(2, 1), (x + 1, 2), (x + 2, 3)]
 
     R, x, y = ring("x,y", ZZ)
     f = -x**5 + x**4 + x - 1
 
     assert R.dmp_sqf_list_in(f, [0, 1]) == (-1, [(x**3 + x**2 + x + 1, 1), (x - 1, 2)])
-    assert R.dmp_sqf_list_include_in(f, [0, 1]) == [(-x**3 - x**2 - x - 1, 1), (x - 1, 2)]
 
     pytest.raises(DomainError, lambda: R.dmp_sqf_norm(x**2 + y**2))
 
     f = -x**2 + 2*x - 1
-    assert R.dmp_sqf_list_include_in(f, [0, 1]) == [(-1, 1), (x - 1, 2)]
 
     R, x, y = ring("x,y", FF(2))
     pytest.raises(NotImplementedError, lambda: R.dmp_sqf_list_in(y**2 + 1, [0, 1]))

--- a/diofant/polys/tests/test_sqfreetools.py
+++ b/diofant/polys/tests/test_sqfreetools.py
@@ -146,9 +146,6 @@ def test_dmp_sqf():
     assert R.dmp_sqf_list(f) == (2, [(x + 1, 2), (x + 2, 3)])
     assert R.dmp_sqf_list_include(f) == [(2, 1), (x + 1, 2), (x + 2, 3)]
 
-    assert R.dmp_sqf_list(f, all=True) == (2, [(1, 1), (x + 1, 2), (x + 2, 3)])
-    assert R.dmp_sqf_list_include(f, all=True) == [(2, 1), (x + 1, 2), (x + 2, 3)]
-
     R, x, y = ring("x,y", ZZ)
     f = -x**5 + x**4 + x - 1
 


### PR DESCRIPTION
- [x] remove all kwarg?
- [x] include constant wrt to the x0 factors to the coefficient of dmp_sqf_list?  This is to preserve ability to reconstruct the polynomial from the dmp_sqf_list's output.
- [x] more generic dmp_sqf_* methods, which will decide if the polynomial is sqf wrt to the some subset of variables, not just the first one.  dmp_sqf_p(f, u, K) -> dmp_sqf_p_in(f, [0], u, K)?
- [x] adapt high-level methods (DMP, Poly's, PolyElement) to use different meaning of being square-free, namely - wrt to __all__ variables.
- [x] naming: Poly.is_sqf vs PolyElement.is_squarefree?
- [x] dmp_sqf_list vs dmp_sqf_list_include.  Do we really need both methods?
- [ ] correct docstrings
- [ ] references (Yun algorithm, etc)
- [ ] release notes
