### PR TITLE
integerals: correct derivation() to return a poly over a field

### DIFF
--- a/diofant/integrals/risch.py
+++ b/diofant/integrals/risch.py
@@ -790,7 +790,7 @@ def derivation(p, DE, coefficientD=False, basic=False):
     if basic:
         r = 0
     else:
-        r = Poly(0, DE.t)
+        r = Poly(0, DE.t, field=True)
 
     t = DE.t
     if coefficientD:
@@ -810,7 +810,7 @@ def derivation(p, DE, coefficientD=False, basic=False):
         if basic:
             r += d.as_expr()*pv.diff(v)
         else:
-            r += (d*pv.diff(v)).as_poly(t)
+            r += (d*pv.diff(v)).as_poly(t, field=True)
 
     if basic:
         r = cancel(r)

--- a/diofant/tests/integrals/test_integrals.py
+++ b/diofant/tests/integrals/test_integrals.py
@@ -1265,3 +1265,7 @@ def test_sympyissue_4491():
 @pytest.mark.xfail
 def test_sympyissue_4514():
     assert not isinstance(integrate(sin(2*x)/sin(x)), Integral)
+
+
+def test_sympyissue_15810():
+    assert integrate(1/(2**(2*x/3) + 1), (x, 0, oo)) == Rational(3, 2)

--- a/diofant/tests/integrals/test_risch.py
+++ b/diofant/tests/integrals/test_risch.py
@@ -124,7 +124,7 @@ def test_hermite_reduce():
         Poly(x**2*t**5 + x*t**4 - nu**2*t**3 - x*(x**2 + 1)*t**2 - (x**2 - nu**2)*t - x**5/4, t),
         Poly(x**2*t**4 + x**2*(x**2 + 2)*t**2 + x**2 + x**4 + x**6/4, t), DE) == \
         ((Poly(-x**2 - 4, t), Poly(4*t**2 + 2*x**2 + 4, t)),
-         (Poly((-2*nu**2 - x**4)*t - (2*x**3 + 2*x), t), Poly(2*x**2*t**2 + x**4 + 2*x**2, t)),
+         (Poly((-nu**2 - x**4/2)*t - x**3 - x, t), Poly(x**2*t**2 + x**4/2 + x**2, t)),
          (Poly(x*t + 1, t), Poly(x, t)))
 
     DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(1/x, t)]})
@@ -157,6 +157,13 @@ def test_hermite_reduce():
         ((Poly(3*t**2 + t + 3*x, t), Poly(3*t**4 - 9*x*t**3 + 9*x**2*t**2 - 3*x**3*t, t)),
          (Poly(0, t), Poly(1, t)),
          (Poly(0, t), Poly(1, t)))
+
+    # issue sympy/sympy#15826
+    DE = DifferentialExtension(extension={'D': [Poly(1, x), Poly(2*log(2)/3*t, t)]})
+
+    assert (hermite_reduce(Poly(1, t), Poly(1 + t), DE) ==
+            ((Poly(0, t), Poly(1, t)), (Poly(1, t), Poly(1 + t)),
+             (Poly(0, t), Poly(1, t))))
 
 
 def test_polynomial_reduce():

--- a/docs/release/notes-0.10.rst
+++ b/docs/release/notes-0.10.rst
@@ -163,3 +163,4 @@ These Sympy issues also were addressed:
 * :sympyissue:`8818` lambdify precision loss with module=mpmath from high-precision Floats
 * :sympyissue:`9544` Finite fields
 * :sympyissue:`15798` Poly.copy() does not copy unused generators
+* :sympyissue:`15810` integrate(1/(2**(2*x/3)+1), (x,0,oo)) is wrong


### PR DESCRIPTION
@jksuom, this is an alternative (single line patch) to https://github.com/sympy/sympy/pull/15826.