### PR TITLE
Real roots isolation for non-sqf polynomials over complex algebraic fields

### DIFF
--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -458,14 +458,8 @@ def dup_isolate_real_roots_sqf(f, K, eps=None, inf=None, sup=None, blackbox=Fals
     f = dmp_clear_denoms(f, 0, K)[1]
 
     if K.is_ComplexAlgebraicField and not K.is_RealAlgebraicField:
-        A, K = K, K.domain
-        polys = [dmp_eval_in(_, K.zero, 1, 1, K) for _ in dup_real_imag(f, A)]
-        if not polys[1]:
-            f = polys[0]
-        else:
-            roots = dup_isolate_real_roots_list(polys, K, eps=eps, inf=inf, sup=sup, strict=True)
-            roots = [_[0] for _ in roots if _[1].keys() == {0, 1}]
-            return [RealInterval((a, b), f, K) for (a, b) in roots] if blackbox else roots
+        roots = [r for r, _ in dup_isolate_real_roots(f, K, eps=eps, inf=inf, sup=sup)]
+        return [RealInterval((a, b), f, K) for (a, b) in roots] if blackbox else roots
 
     if dmp_degree_in(f, 0, 0) <= 0:
         return []

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -496,6 +496,15 @@ def dup_isolate_real_roots(f, K, eps=None, inf=None, sup=None):
     if not (K.is_ComplexAlgebraicField or K.is_RationalField):
         raise DomainError("isolation of real roots not supported over %s" % K)
 
+    if K.is_ComplexAlgebraicField and not K.is_RealAlgebraicField:
+        A, K = K, K.domain
+        polys = [dmp_eval_in(_, K.zero, 1, 1, K) for _ in dup_real_imag(f, A)]
+        if not polys[1]:
+            f = polys[0]
+        else:
+            roots = dup_isolate_real_roots_list(polys, K, eps=eps, inf=inf, sup=sup, strict=True)
+            return [(_[0], _[1][0]) for _ in roots if _[1].keys() == {0, 1}]
+
     _, factors = dmp_sqf_list(f, 0, K)
     factors = [(dmp_clear_denoms(f, 0, K)[1], k) for f, k in factors]
 

--- a/diofant/polys/rootisolation.py
+++ b/diofant/polys/rootisolation.py
@@ -493,11 +493,8 @@ def dup_isolate_real_roots(f, K, eps=None, inf=None, sup=None):
     if K.is_ComplexAlgebraicField and not K.is_RealAlgebraicField:
         A, K = K, K.domain
         polys = [dmp_eval_in(_, K.zero, 1, 1, K) for _ in dup_real_imag(f, A)]
-        if not polys[1]:
-            f = polys[0]
-        else:
-            roots = dup_isolate_real_roots_list(polys, K, eps=eps, inf=inf, sup=sup, strict=True)
-            return [(_[0], _[1][0]) for _ in roots if _[1].keys() == {0, 1}]
+        roots = dup_isolate_real_roots_list(polys, K, eps=eps, inf=inf, sup=sup, strict=True)
+        return [(_[0], _[1][0]) for _ in roots if _[1].keys() == {0, 1}]
 
     _, factors = dmp_sqf_list(f, 0, K)
     factors = [(dmp_clear_denoms(f, 0, K)[1], k) for f, k in factors]
@@ -543,10 +540,15 @@ def dup_isolate_real_roots_list(polys, K, eps=None, inf=None, sup=None, strict=F
     factors = collections.defaultdict(dict)
 
     for i, p in enumerate(polys):
+        ni = (i + 1) % 2
+
+        if not p and zeros and ni in zero_indices:
+            zero_indices[i] = zero_indices[ni]
+
         for f, _ in dmp_sqf_list(dmp_gcd(p, gcd, 0, K), 0, K)[1]:
             k1 = dmp_trial_division(gcd, [f], 0, K)[0][1]
             k2 = dmp_trial_division(p, [f], 0, K)[0][1]
-            factors[tuple(f)] = {i: k1 + k2, (i + 1) % 2: k1}
+            factors[tuple(f)] = {i: k1 + k2, ni: k1}
 
             gcd = dmp_quo(gcd, dmp_pow(f, k1, 0, K), 0, K)
             p = dmp_quo(p, dmp_pow(f, k2, 0, K), 0, K)

--- a/diofant/tests/polys/test_rootisolation.py
+++ b/diofant/tests/polys/test_rootisolation.py
@@ -439,7 +439,7 @@ def test_dup_isolate_real_roots():
     f = x**4*(x - 1)**3*(x**2 - 2)**2
 
     assert R.dup_isolate_real_roots(f) == \
-        [((-2, -1), 2), ((0, 0), 4), ((1, 1), 3), ((1, 2), 2)]
+        [((-2, -1), 2), ((0, 0), 4), ((1, 1), 3), ((QQ(4, 3), QQ(3, 2)), 2)]
 
 
 def test_dup_isolate_real_roots_list():
@@ -495,6 +495,16 @@ def test_dup_isolate_real_roots_list():
     assert R.dup_isolate_real_roots_list([f, g], basis=True) == \
         [((-2, -1), {0: 2}, [1, 0, -2]), ((0, 0), {0: 2, 1: 1}, [1, 0]),
          ((1, 1), {0: 3, 1: 2}, [1, -1]), ((1, 2), {0: 2}, [1, 0, -2])]
+
+    f, g = x, R.zero
+
+    assert R.dup_isolate_real_roots_list([f, g]) == \
+        R.dup_isolate_real_roots_list([g, f]) == [((0, 0), {0: 1, 1: 1})]
+
+    f *= x**2
+
+    assert R.dup_isolate_real_roots_list([f, g]) == \
+        R.dup_isolate_real_roots_list([g, f]) == [((0, 0), {0: 3, 1: 3})]
 
     R, x = ring("x", EX)
 

--- a/diofant/tests/polys/test_rootisolation.py
+++ b/diofant/tests/polys/test_rootisolation.py
@@ -429,6 +429,18 @@ def test_dup_isolate_real_roots():
     pytest.raises(DomainError, lambda: R.dup_isolate_real_roots(x + 3))
     pytest.raises(DomainError, lambda: R.dup_isolate_real_roots((x + 2)*(x + 3)**2))
 
+    R, x = ring("x", QQ.algebraic_field(I))
+
+    f = (x**2 - I)**2*(x - 2*I)**3
+
+    assert R.dup_isolate_real_roots(f) == []  # issue diofant/diofant#789
+    assert R.dup_isolate_real_roots(f*(x - 1)**3) == [((1, 1), 3)]
+
+    f = x**4*(x - 1)**3*(x**2 - 2)**2
+
+    assert R.dup_isolate_real_roots(f) == \
+        [((-2, -1), 2), ((0, 0), 4), ((1, 1), 3), ((1, 2), 2)]
+
 
 def test_dup_isolate_real_roots_list():
     R, x = ring("x", ZZ)


### PR DESCRIPTION
Mostly same approach as [here](https://github.com/diofant/diofant/blob/3c0c949945de691ad16794cf06c2ebc1eaf5ae18/diofant/polys/rootisolation.py#L460-L468) in the `dup_isolate_real_roots_sqf()`.
