### PR TITLE
New factorization algorithm for polynomials over algebraic number fields

### DIFF
--- a/diofant/__init__.py
+++ b/diofant/__init__.py
@@ -57,7 +57,7 @@ from .domains import (CC, EX, FF, GF, GROUND_TYPES, QQ, RR, ZZ, AlgebraicField,
                       ExpressionDomain, FF_gmpy, FF_python, FiniteField,
                       IntegerRing, PythonRational, QQ_gmpy, QQ_python,
                       RationalField, RealAlgebraicField, RealField, ZZ_gmpy,
-                      ZZ_python)
+                      ZZ_python, FiniteRing)
 from .series import Limit, O, Order, limit, residue, series
 from .functions import (E1, Abs, Chi, Ci, DiracDelta, Ei, Eijk,
                         FallingFactorial, Heaviside, Id, KroneckerDelta,
@@ -307,4 +307,4 @@ __all__ = (
     'plot_backends', 'plot_implicit', 'plot_parametric', 'StrPrinter', 'ccode',
     'dotprint', 'fcode', 'latex', 'mathematica_code', 'mathml', 'octave_code',
     'pprint', 'pprint_use_unicode', 'pretty', 'pretty_print', 'python', 'srepr',
-    'sstr', 'sstrrepr', 'init_printing', 'ExtendedReals')
+    'sstr', 'sstrrepr', 'init_printing', 'ExtendedReals', 'FiniteRing')

--- a/diofant/domains/__init__.py
+++ b/diofant/domains/__init__.py
@@ -6,7 +6,7 @@ from .algebraicfield import (AlgebraicField, ComplexAlgebraicField,
 from .complexfield import CC, ComplexField
 from .domain import Domain
 from .expressiondomain import EX, ExpressionDomain
-from .finitefield import FiniteField
+from .finitefield import FiniteField, FiniteRing
 from .finitefield import GMPYFiniteField as FF_gmpy
 from .finitefield import PythonFiniteField as FF_python
 from .groundtypes import PythonRational
@@ -26,4 +26,4 @@ __all__ = ('GROUND_TYPES', 'AlgebraicField', 'ComplexAlgebraicField',
            'ExpressionDomain', 'FiniteField', 'FF_gmpy', 'FF_python',
            'PythonRational', 'IntegerRing', 'ZZ_gmpy', 'ZZ_python',
            'QQ_gmpy', 'QQ_python', 'RationalField', 'RR', 'RealField',
-           'FF', 'ZZ', 'QQ', 'GF')
+           'FF', 'ZZ', 'QQ', 'GF', 'FiniteRing')

--- a/diofant/domains/finitefield.py
+++ b/diofant/domains/finitefield.py
@@ -5,51 +5,28 @@ import random
 import typing
 
 from ..core import Dummy, integer_digits
-from ..ntheory import factorint, is_primitive_root
+from ..ntheory import factorint, is_primitive_root, isprime
 from ..polys.polyerrors import CoercionFailed
 from .field import Field
 from .groundtypes import DiofantInteger
 from .integerring import GMPYIntegerRing, PythonIntegerRing, ZZ_python
 from .quotientring import QuotientRingElement
+from .ring import Ring
 from .simpledomain import SimpleDomain
 
 
-class FiniteField(Field, SimpleDomain):
-    """General class for finite fields."""
+class FiniteRing(Ring, SimpleDomain):
+    """General class for quotient rings over integers."""
 
-    is_FiniteField = True
     is_Numerical = True
 
-    def __new__(cls, order, dom, modulus=None):
-        try:
-            pp = factorint(order)
-            if not order or len(pp) != 1:
-                raise ValueError
-            mod, deg = pp.popitem()
-        except ValueError:
-            raise ValueError(f'order must be a prime power, got {order}')
+    def __new__(cls, order, dom):
+        if isprime(order):
+            return dom.finite_field(order)
 
-        if deg == 1:
-            if modulus:
-                deg = len(modulus) - 1
-            else:
-                modulus = [1, 0]
+        mod = dom.convert(order)
 
-        order = mod**deg
-
-        if modulus is None:
-            random.seed(0)
-            ring = ZZ_python.finite_field(mod).inject(Dummy('x'))
-            modulus = ring._gf_random(deg, irreducible=True).all_coeffs()
-        elif deg != len(modulus) - 1:
-            raise ValueError('degree of a defining polynomial for the field'
-                             ' does not match extension degree')
-
-        modulus = tuple(map(dom.dtype, modulus))
-
-        mod = dom.convert(mod)
-
-        key = order, dom, mod, modulus
+        key = cls, order, dom
 
         obj = super().__new__(cls)
 
@@ -57,24 +34,13 @@ class FiniteField(Field, SimpleDomain):
         obj.mod = mod
         obj.order = order
 
-        if order > mod:
-            obj.rep = f'GF({obj.mod}, {list(map(ZZ_python, modulus))})'
-        else:
-            obj.rep = f'GF({obj.mod})'
+        obj.rep = f'FiniteRing({obj.order})'
 
         try:
             obj.dtype = _modular_integer_cache[key]
         except KeyError:
-            if deg == 1:
-                obj.dtype = type('ModularInteger', (ModularInteger,),
-                                 {'mod': mod, 'domain': dom, '_parent': obj})
-            else:
-                ff = dom.finite_field(mod).inject(Dummy('x'))
-                mod = ff.from_list(modulus)
-                if not mod.is_irreducible:
-                    raise ValueError('defining polynomial must be irreducible')
-                obj.dtype = type('GaloisFieldElement', (GaloisFieldElement,),
-                                 {'mod': mod, 'domain': ff, '_parent': obj})
+            obj.dtype = type('ModularInteger', (ModularInteger,),
+                             {'mod': mod, 'domain': dom, '_parent': obj})
             _modular_integer_cache[key] = obj.dtype
 
         obj.zero = obj.dtype(0)
@@ -86,7 +52,7 @@ class FiniteField(Field, SimpleDomain):
         return hash((self.__class__.__name__, self.dtype, self.order, self.domain))
 
     def __eq__(self, other):
-        return isinstance(other, FiniteField) and \
+        return isinstance(other, self.__class__) and \
             self.order == other.order and self.domain == other.domain
 
     def __getnewargs_ex__(self):
@@ -94,7 +60,7 @@ class FiniteField(Field, SimpleDomain):
 
     @property
     def characteristic(self):
-        return self.mod
+        return self.order
 
     def to_expr(self, element):
         return DiofantInteger(int(element))
@@ -135,7 +101,93 @@ class FiniteField(Field, SimpleDomain):
         return True
 
 
-_modular_integer_cache: typing.Dict[tuple, FiniteField] = {}
+class FiniteField(Field, FiniteRing):
+    """General class for finite fields."""
+
+    is_FiniteField = True
+
+    def __new__(cls, order, dom, modulus=None):
+        try:
+            pp = factorint(order)
+            if not order or len(pp) != 1:
+                raise ValueError
+            mod, deg = pp.popitem()
+        except ValueError:
+            raise ValueError(f'order must be a prime power, got {order}')
+
+        if deg == 1:
+            if modulus:
+                deg = len(modulus) - 1
+            else:
+                modulus = [1, 0]
+
+        order = mod**deg
+
+        if modulus is None:
+            random.seed(0)
+            ring = ZZ_python.finite_field(mod).inject(Dummy('x'))
+            modulus = ring._gf_random(deg, irreducible=True).all_coeffs()
+        elif deg != len(modulus) - 1:
+            raise ValueError('degree of a defining polynomial for the field'
+                             ' does not match extension degree')
+
+        modulus = tuple(map(dom.dtype, modulus))
+
+        mod = dom.convert(mod)
+
+        key = cls, order, dom, mod, modulus
+
+        obj = super(FiniteRing, cls).__new__(cls)  # pylint: disable=bad-super-call
+
+        obj.domain = dom
+        obj.mod = mod
+        obj.order = order
+
+        if order > mod:
+            obj.rep = f'GF({obj.mod}, {list(map(ZZ_python, modulus))})'
+        else:
+            obj.rep = f'GF({obj.mod})'
+
+        try:
+            obj.dtype = _modular_integer_cache[key]
+        except KeyError:
+            if deg == 1:
+                obj.dtype = type('ModularInteger', (ModularInteger,),
+                                 {'mod': mod, 'domain': dom, '_parent': obj})
+            else:
+                ff = dom.finite_field(mod).inject(Dummy('x'))
+                mod = ff.from_list(modulus)
+                if not mod.is_irreducible:
+                    raise ValueError('defining polynomial must be irreducible')
+                obj.dtype = type('GaloisFieldElement', (GaloisFieldElement,),
+                                 {'mod': mod, 'domain': ff, '_parent': obj})
+            _modular_integer_cache[key] = obj.dtype
+
+        obj.zero = obj.dtype(0)
+        obj.one = obj.dtype(1)
+
+        return obj
+
+    @property
+    def characteristic(self):
+        return self.mod
+
+
+_modular_integer_cache: typing.Dict[tuple, FiniteRing] = {}
+
+
+class PythonFiniteRing(FiniteRing):
+    """Quotient ring based on Python's integers."""
+
+    def __new__(cls, order):
+        return super().__new__(cls, order, PythonIntegerRing())
+
+
+class GMPYFiniteRing(FiniteRing):
+    """Quotient ring based on GMPY's integers."""
+
+    def __new__(cls, order):
+        return super().__new__(cls, order, GMPYIntegerRing())
 
 
 class PythonFiniteField(FiniteField):

--- a/diofant/domains/integerring.py
+++ b/diofant/domains/integerring.py
@@ -47,6 +47,9 @@ class IntegerRing(CharacteristicZero, SimpleDomain, Ring):
         return self.dtype(int(a))
     _from_GMPYFiniteField = _from_PythonFiniteField
 
+    _from_GMPYFiniteRing = _from_PythonFiniteField
+    _from_PythonFiniteRing = _from_PythonFiniteField
+
     def _from_PythonRationalField(self, a, K0):
         if a.denominator == 1:
             return self.dtype(a.numerator)
@@ -65,6 +68,11 @@ class IntegerRing(CharacteristicZero, SimpleDomain, Ring):
     @abc.abstractmethod
     def finite_field(self, p):
         """Returns a finite field."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def finite_ring(self, n):
+        """Returns a finite ring."""
         raise NotImplementedError
 
 
@@ -100,6 +108,11 @@ class PythonIntegerRing(IntegerRing):
         from .finitefield import PythonFiniteField
         return PythonFiniteField(p)
 
+    def finite_ring(self, n):
+        """Returns a finite ring."""
+        from .finitefield import PythonFiniteRing
+        return PythonFiniteRing(n)
+
 
 class GMPYIntegerRing(IntegerRing):
     """Integer ring based on GMPY's integers."""
@@ -133,6 +146,11 @@ class GMPYIntegerRing(IntegerRing):
         """Returns a finite field."""
         from .finitefield import GMPYFiniteField
         return GMPYFiniteField(p)
+
+    def finite_ring(self, n):
+        """Returns a finite ring."""
+        from .finitefield import GMPYFiniteRing
+        return GMPYFiniteRing(n)
 
 
 ZZ_python = PythonIntegerRing()

--- a/diofant/polys/factorization_alg_field.py
+++ b/diofant/polys/factorization_alg_field.py
@@ -243,7 +243,7 @@ def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
         pi = gcd(omega, divisors[i])
         divisors[i] //= pi
         if divisors[i] == 1:
-            return
+            raise NotImplementedError
 
     e = []
 
@@ -502,7 +502,7 @@ def _div(f, g, minpoly, p):
     lcinv, _, gcd = _gf_gcdex(g.eject(*ring.gens[1:]).LC, minpoly, p)
 
     if not gcd == 1:
-        return
+        raise NotImplementedError
 
     quotient = ring.zero
 
@@ -539,7 +539,7 @@ def _extended_euclidean_algorithm(f, g, minpoly, p):
     while g:
         result = _div(f, g, minpoly, p)
         if result is None:
-            return
+            raise NotImplementedError
         else:
             quo, rem = result
         f, g = g, rem
@@ -567,7 +567,7 @@ def _diophantine_univariate(F, m, minpoly, p):
         f, g = F
         result = _extended_euclidean_algorithm(g, f, minpoly, p)
         if result is None:
-            return
+            raise NotImplementedError
         else:
             s, t, _ = result
 
@@ -594,7 +594,7 @@ def _diophantine_univariate(F, m, minpoly, p):
         for f, g in zip(F, G):
             result = _diophantine([g, f], T[-1], [], 0, minpoly, p)
             if result is None:
-                return
+                raise NotImplementedError
             else:
                 t, s = result
             T.append(t)
@@ -625,7 +625,7 @@ def _diophantine(F, c, A, d, minpoly, p):
         for (exp,), coeff in c.eject(1).items():
             T = _diophantine_univariate(F, exp, minpoly, p)
             if T is None:
-                return
+                raise NotImplementedError
 
             for j, (s, t) in enumerate(zip(S, T)):
                 S[j] = _trunc(s + t*coeff.set_ring(ring), minpoly, p)
@@ -644,7 +644,7 @@ def _diophantine(F, c, A, d, minpoly, p):
 
         S = _diophantine(G, C, A, d, minpoly, p)
         if S is None:
-            return
+            raise NotImplementedError
         else:
             S = [s.set_ring(ring) for s in S]
 
@@ -667,7 +667,7 @@ def _diophantine(F, c, A, d, minpoly, p):
                 C = C.quo_ground(ring.domain.factorial(k + 1))
                 T = _diophantine(G, C, A, d, minpoly, p)
                 if T is None:
-                    return
+                    raise NotImplementedError
 
                 for i, t in enumerate(T):
                     T[i] = t.set_ring(ring) * M
@@ -679,6 +679,8 @@ def _diophantine(F, c, A, d, minpoly, p):
                     c = c - t * b
 
                 c = _trunc(c, minpoly, p)
+            else:
+                raise NotImplementedError
 
         S = [_trunc(s, minpoly, p) for s in S]
 
@@ -759,7 +761,7 @@ def _hensel_lift(f, H, LC, A, minpoly, p):
                 C = C.quo_ground(ring.domain.factorial(k + 1))  # coeff of (x_{j-1} - a_{j-1})^(k + 1) in c
                 T = _diophantine(G, C, I, d, minpoly, p)
                 if T is None:
-                    return
+                    raise NotImplementedError
 
                 for i, (h, t) in enumerate(zip(H, T)):
                     H[i] = _trunc(h + t.set_ring(Hring)*M, minpoly, p)

--- a/diofant/polys/factorization_alg_field.py
+++ b/diofant/polys/factorization_alg_field.py
@@ -383,26 +383,6 @@ def _subs_ground(f, A):
     return f_
 
 
-def _choose_particular_solution(solution, ring):
-    r"""
-    Choose a particular solution of the parametrized solution of a linear
-    system.
-
-    """
-    domain = ring.domain
-    gens = list(ring.gens)
-    sol = {}
-
-    for k, v in solution.items():
-        sol[k] = v.coeff(1)
-        gens.remove(k)
-
-    for k in gens:
-        sol[k] = domain.zero
-
-    return sol
-
-
 def _padic_lift(f, pfactors, lcs, B, minpoly, p):
     r"""
     Lift the factorization of a polynomial over `\mathbb Z_p[z]/(\mu(z))` to
@@ -494,8 +474,8 @@ def _padic_lift(f, pfactors, lcs, B, minpoly, p):
         else:
             solution = {k.set_domain(domain): v.set_domain(domain).trunc_ground(P)
                         for k, v in solution.items()}
+            assert len(solution) == coeffring.ngens
 
-        solution = _choose_particular_solution(solution, coeffring)
         subs = list(solution.items())
 
         H = [h + _subs_ground(s, subs).mul_ground(P) for h, s in zip(H, S)]

--- a/diofant/polys/factorization_alg_field.py
+++ b/diofant/polys/factorization_alg_field.py
@@ -1,0 +1,1011 @@
+import functools
+import operator
+import random
+
+from ..core import Dummy
+from ..domains.algebraicfield import AlgebraicElement
+from ..integrals.heurisch import _symbols
+from ..ntheory import nextprime
+from .modulargcd import (_euclidean_algorithm, _gf_gcdex, _minpoly_from_dense,
+                         _trunc)
+from .polyconfig import using
+from .polyerrors import NotInvertible, UnluckyLeadingCoefficient
+from .polyutils import _sort_factors
+from .rings import PolynomialRing
+from .solvers import solve_lin_sys
+
+
+# TODO
+# ====
+
+# -) efficiency of _factor can be improved for irreducible polynomials if the
+#    univariate factorization is done before the LC is factored
+
+
+def _alpha_to_z(f, ring):
+    r"""
+    Change the representation of a polynomial over
+    `\mathbb Q(\alpha)` by replacing the algebraic element `\alpha` by a new
+    variable `z`.
+
+    Parameters
+    ==========
+
+    f : PolyElement
+        polynomial in `\mathbb Q(\alpha)[x_0, \ldots, x_n]`
+    ring : PolynomialRing
+        the polynomial ring `\mathbb Q[x_0, \ldots, x_n, z]`
+
+    Returns
+    =======
+
+    f_ : PolyElement
+        polynomial in `\mathbb Q[x_0, \ldots, x_n, z]`
+
+    """
+    if isinstance(f, AlgebraicElement):
+        ring = ring.drop(*ring.gens[:-1])
+        f_ = ring(dict(f.rep))
+
+    else:
+        f_ = ring.zero
+
+        for monom, coeff in f.items():
+            coeff = coeff.rep.all_coeffs()
+            n = len(coeff)
+
+            for i in range(n):
+                m = monom + (n-i-1,)
+                if coeff[i]:
+                    f_[m] = coeff[i]
+
+    return f_
+
+
+def _z_to_alpha(f, ring):
+    r"""
+    Change the representation of a polynomial in
+    `\mathbb Q[x_0, \ldots, x_n, z]` by replacing the variable `z` by the
+    algebraic element `\alpha` of the given ring
+    `\mathbb Q(\alpha)[x_0, \ldots, x_n]`.
+
+    Parameters
+    ==========
+
+    f : PolyElement
+        polynomial in `\mathbb Q[x_0, \ldots, x_n, z]`
+    ring : PolynomialRing
+        the polynomial ring `\mathbb Q(\alpha)[x_0, \ldots, x_n]`
+
+    Returns
+    =======
+
+    f_ : PolyElement
+        polynomial in `\mathbb Q(\alpha)[x_0, \ldots, x_n]`
+
+    """
+    domain = ring.domain
+
+    f_ = ring.zero
+    for monom, coeff in f.items():
+        m = monom[:-1]
+        c = domain([domain.domain(coeff)] + [0]*monom[-1])
+
+        if m not in f_:
+            f_[m] = c
+        else:
+            f_[m] += c
+
+    return f_
+
+
+def _distinct_prime_divisors(S, domain):
+    r"""
+    Try to find pairwise coprime divisors of all elements of a given list
+    `S` of integers.
+
+    If this fails, ``None`` is returned.
+
+    References
+    ==========
+
+    * :cite:`Javadi2009factor`
+
+    """
+    gcd = domain.gcd
+    divisors = []
+
+    for i, s in enumerate(S):
+        divisors.append(s)
+
+        for j in range(i):
+            g = gcd(divisors[i], divisors[j])
+            divisors[i] = divisors[i] // g
+            divisors[j] = divisors[j] // g
+            g1 = gcd(divisors[i], g)
+            g2 = gcd(divisors[j], g)
+
+            while g1 != 1:
+                g1 = gcd(divisors[i], g1)
+                divisors[i] = divisors[i] // g1
+
+            while g2 != 1:
+                g2 = gcd(divisors[j], g2)
+                divisors[j] = divisors[j] // g2
+
+            if divisors[i] == 1 or divisors[j] == 1:
+                return
+
+    return divisors
+
+
+def _denominator(f):
+    r"""
+    Compute the denominator `\mathrm{den}(f)` of a polynomial `f` over
+    `\mathbb Q`, i.e. the smallest integer such that `\mathrm{den}(f) f` is
+    a polynomial over `\mathbb Z`.
+
+    """
+    ring = f.ring.domain.ring
+    lcm = ring.lcm
+    den = ring.one
+
+    for coeff in f.values():
+        den = lcm(den, coeff.denominator)
+
+    return den
+
+
+def _monic_associate(f, ring):
+    r"""
+    Compute the monic associate of a polynomial `f` over
+    `\mathbb Q(\alpha)`, which is defined as
+
+    .. math ::
+
+        \mathrm{den}\left( \frac 1 {\mathrm{lc}(f)} f \right) \cdot \frac 1 {\mathrm{lc}(f)} f.
+
+    The result is a polynomial in `\mathbb Z[x_0, \ldots, x_n, z]`.
+
+    See also
+    ========
+
+    _denominator
+    _alpha_to_z
+
+    """
+    qring = ring.clone(domain=ring.domain.field)
+    f = _alpha_to_z(f.monic(), qring)
+    f_ = f.clear_denoms()[1].set_ring(ring)
+
+    return f_.primitive()[1]
+
+
+def _leading_coeffs(f, U, gamma, lcfactors, A, D, denoms, divisors):
+    r"""
+    Compute the true leading coefficients in `x_0` of the irreducible
+    factors of a polynomial `f`.
+
+    If this fails, ``None`` is returned.
+
+    Parameters
+    ==========
+
+    f : PolyElement
+        squarefree polynomial in `Z[x_0, \ldots, x_n, z]`
+    U : list of PolyElement objects
+        monic univariate factors of `f(x_0, A)` in `\mathbb Q(\alpha)[x_0]`
+    gamma : Integer
+        integer content of `\mathrm{lc}_{x_0}(f)`
+    lcfactors : list of (PolyElement, Integer) objects
+        factorization of `\mathrm{lc}_{x_0}(f)` in
+        `\mathbb Z[x_1, \ldots, x_n, z]`
+    A : list of Integer objects
+        the evaluation point `[a_1, \ldots, a_n]`
+    D : Integer
+        integral multiple of the defect of `\mathbb Q(\alpha)`
+    denoms : list of Integer objects
+        denominators of `\frac 1 {l(A)}` for `l` in ``lcfactors``
+    divisors : list of Integer objects
+        pairwise coprime divisors of all elements of ``denoms``
+
+    Returns
+    =======
+
+    f : PolyElement
+        possibly updated polynomial `f`
+    lcs : list of PolyElement objects
+        true leading coefficients of the irreducible factors of `f`
+    U_ : list of PolyElement objects
+        list of possibly updated monic associates of the univariate factors
+        `U`
+
+    References
+    ==========
+
+    * :cite:`Javadi2009factor`
+
+    """
+    ring = f.ring
+    domain = ring.domain
+    symbols = f.ring.symbols
+    qring = ring.clone(symbols=(symbols[0], symbols[-1]), domain=domain.field)
+    gcd = domain.gcd
+
+    U = [_alpha_to_z(u, qring) for u, _ in U]
+    denominators = [_denominator(u) for u in U]
+
+    omega = D * gamma
+
+    m = len(denoms)
+
+    for i in range(m):
+        pi = gcd(omega, divisors[i])
+        divisors[i] //= pi
+        if divisors[i] == 1:
+            return
+
+    e = []
+
+    for dj in denominators:
+        ej = []
+
+        for i in range(m):
+            eji = 0
+            g1 = gcd(dj, divisors[i])
+
+            while g1 != 1:
+                eji += 1
+                dj = dj // g1
+                g1 = gcd(dj, g1)
+
+            ej.append(eji)
+
+        e.append(ej)
+
+    n = len(denominators)
+    if any(sum(e[j][i] for j in range(n)) != lcfactors[i][1] for i in range(m)):
+        return
+
+    lcring = ring.drop(0)
+    lcs = []
+    for j in range(n):
+        lj = functools.reduce(operator.mul, [lcfactors[i][0]**e[j][i] for i in range(m)], lcring.one)
+        lcs.append(lj)
+
+    zring = qring.clone(domain=domain)
+
+    for j in range(n):
+        lj = lcs[j]
+        dj = denominators[j]
+        ljA = lj.eval(list(zip(lcring.gens, A)))
+
+        lcs[j] = lj.mul_ground(dj)
+        U[j] = U[j].mul_ground(dj).set_ring(zring) * ljA.set_ring(zring)
+
+        if omega == 1:
+            f = f.mul_ground(dj)
+        else:
+            d = gcd(omega, dj)
+            f = f.mul_ground(dj // d)
+
+    if omega != 1:
+        lcs[0] = lcs[0].mul_ground(omega)
+        U[0] = U[0].mul_ground(omega)
+
+    return f, lcs, U
+
+
+def _test_evaluation_points(f, gamma, lcfactors, A, D):
+    r"""
+    Test if an evaluation point is suitable for _factor.
+
+    If it is not, ``None`` is returned.
+
+    Parameters
+    ==========
+
+    f : PolyElement
+        squarefree polynomial in `\mathbb Z[x_0, \ldots, x_n, z]`
+    gamma : Integer
+        leading coefficient of `f` in `\mathbb Z`
+    lcfactors : list of (PolyElement, Integer) objects
+        factorization of `\mathrm{lc}_{x_0}(f)` in
+        `\mathbb Z[x_1, \ldots, x_n, z]`
+    A : list of Integer objects
+        the evaluation point `[a_1, \ldots, a_n]`
+    D : Integer
+        integral multiple of the defect of `\mathbb Q(\alpha)`
+
+    Returns
+    =======
+
+    fA : PolyElement
+        `f` evaluated at `A`, i.e. `f(x_0, A)`
+    denoms : list of Integer objects
+        the denominators of `\frac 1 {l(A)}` for `l` in ``lcfactors``
+    divisors : list of Integer objects
+        pairwise coprime divisors of all elements of ``denoms``
+
+    References
+    ==========
+
+    * :cite:`Javadi2009factor`
+
+    See also
+    ========
+
+    _factor
+
+    """
+    ring = f.ring
+    qring = ring.clone(domain=ring.domain.field)
+
+    fA = f.eval(list(zip(ring.gens[1:-1], A)))
+
+    if fA.degree() < f.degree():
+        return
+
+    if not fA.is_squarefree:
+        return
+
+    omega = gamma * D
+    denoms = []
+    for l, _ in lcfactors:
+        lA = l.eval(list(zip(l.ring.gens, A)))  # in Q(alpha)
+        denoms.append(_denominator(_alpha_to_z(lA**(-1), qring)))
+
+    if any(denoms.count(denom) > 1 for denom in denoms):
+        raise UnluckyLeadingCoefficient
+
+    divisors = _distinct_prime_divisors(denoms, ring.domain)
+
+    if divisors is None:
+        return
+    elif any(omega % d == 0 for d in divisors):
+        return
+
+    return fA, denoms, divisors
+
+
+def _subs_ground(f, A):
+    r"""
+    Substitute variables in the coefficients of a polynomial `f` over a
+    ``PolynomialRing``.
+
+    """
+    f_ = f.ring.zero
+
+    for monom, coeff in f.items():
+        if coeff.compose(A):
+            f_[monom] = coeff.compose(A)
+
+    return f_
+
+
+def _choose_particular_solution(solution, ring):
+    r"""
+    Choose a particular solution of the parametrized solution of a linear
+    system.
+
+    """
+    domain = ring.domain
+    gens = list(ring.gens)
+    sol = {}
+
+    for k, v in solution.items():
+        sol[k] = v.coeff(1)
+        gens.remove(k)
+
+    for k in gens:
+        sol[k] = domain.zero
+
+    return sol
+
+
+def _padic_lift(f, pfactors, lcs, B, minpoly, p):
+    r"""
+    Lift the factorization of a polynomial over `\mathbb Z_p[z]/(\mu(z))` to
+    a factorization over `\mathbb Z_{p^m}[z]/(\mu(z))`, where `p^m \geq B`.
+
+    If this fails, ``None`` is returned.
+
+    Parameters
+    ==========
+
+    f : PolyElement
+        squarefree polynomial in `\mathbb Z[x_0, \ldots, x_n, z]`
+    pfactors : list of PolyElement objects
+        irreducible factors of `f` modulo `p`
+    lcs : list of PolyElement objects
+        true leading coefficients in `x_0` of the irreducible factors of `f`
+    B : Integer
+        heuristic numerical bound on the size of the largest integer
+        coefficient in the irreducible factors of `f`
+    minpoly : PolyElement
+        minimal polynomial `\mu` of `\alpha` over `\mathbb Q`
+    p : Integer
+        prime number
+
+    Returns
+    =======
+
+    H : list of PolyElement objects
+        factorization of `f` modulo `p^m`, where `p^m \geq B`
+
+    References
+    ==========
+
+    * :cite:`Javadi2009factor`
+
+    """
+    ring = f.ring
+    domain = ring.domain
+
+    x = ring.gens[0]
+    tails = [g - g.eject(*ring.gens[1:]).LC.set_ring(ring)*x**g.degree() for g in pfactors]
+
+    coeffs = []
+    for i, g in enumerate(tails):
+        coeffs += _symbols(f'c{i}', len(g))
+
+    coeffring = PolynomialRing(domain, coeffs)
+    ring_ = ring.clone(domain=coeffring)
+
+    S = []
+    k = 0
+    for t in tails:
+        s = ring_.zero
+        r = len(t)
+        for i, monom in zip(range(k, k + r), t):
+            s[monom] = coeffring.gens[i]
+        S.append(s)
+        k += r
+
+    m = minpoly.set_ring(ring_)
+    f = f.set_ring(ring_)
+    x = ring_.gens[0]
+    H = [t.set_ring(ring_) + li.set_ring(ring_)*x**g.degree() for t, g, li in
+         zip(tails, pfactors, lcs)]
+
+    prod = functools.reduce(operator.mul, H)
+    e = (f - prod) % m
+
+    P = p
+    while e and P < 2*B:
+        poly = e // P
+
+        for s, h in zip(S, H):
+            poly -= (prod//h)*s
+
+        poly = _trunc(poly, m, P)
+
+        P_domain = domain.finite_ring(P)
+
+        try:
+            solution = solve_lin_sys([_.set_domain(P_domain)
+                                      for _ in poly.coeffs()],
+                                     coeffring.clone(domain=P_domain))
+        except NotInvertible:
+            return
+
+        if solution is None:
+            return
+        else:
+            solution = {k.set_domain(domain): v.set_domain(domain).trunc_ground(P)
+                        for k, v in solution.items()}
+
+        solution = _choose_particular_solution(solution, coeffring)
+        subs = list(solution.items())
+
+        H = [h + _subs_ground(s, subs).mul_ground(P) for h, s in zip(H, S)]
+        P = P**2
+        prod = functools.reduce(operator.mul, H)
+        e = (f - prod) % m
+
+    if e == 0:
+        return [h.set_ring(ring) for h in H]
+    else:
+        return
+
+
+def _div(f, g, minpoly, p):
+    r"""
+    Division with remainder for univariate polynomials over
+    `\mathbb Z_p[z]/(\mu(z))`.
+
+    """
+    ring = f.ring
+
+    rem = f
+    deg = g.degree(0)
+    lcinv, _, gcd = _gf_gcdex(g.eject(*ring.gens[1:]).LC, minpoly, p)
+
+    if not gcd == 1:
+        return
+
+    quotient = ring.zero
+
+    while True:
+        degrem = rem.degree(0)
+        if degrem < deg:
+            break
+        quo = (lcinv * rem.eject(*ring.gens[1:]).LC).set_ring(ring).mul_monom((degrem - deg, 0))
+        rem = _trunc(rem - g*quo, minpoly, p)
+        quotient += quo
+
+    return _trunc(quotient, minpoly, p), rem
+
+
+def _extended_euclidean_algorithm(f, g, minpoly, p):
+    r"""
+    Extended Euclidean Algorithm for univariate polynomials over
+    `\mathbb Z_p[z]/(\mu(z))`.
+
+    Returns `s, t, h`, where `h` is the GCD of `f` and `g` and
+    `sf + tg = h`.
+
+    """
+    ring = f.ring
+    zero = ring.zero
+    one = ring.one
+
+    f = _trunc(f, minpoly, p)
+    g = _trunc(g, minpoly, p)
+
+    s0, s1 = zero, one
+    t0, t1 = one, zero
+
+    while g:
+        result = _div(f, g, minpoly, p)
+        if result is None:
+            return
+        else:
+            quo, rem = result
+        f, g = g, rem
+        s0, s1 = s1 - quo*s0, s0
+        t0, t1 = t1 - quo*t0, t0
+
+    lcfinv = _gf_gcdex(f.eject(*ring.gens[1:]).LC, minpoly, p)[0].set_ring(ring)
+
+    return (_trunc(s1 * lcfinv, minpoly, p), _trunc(t1 * lcfinv, minpoly, p),
+            _trunc(f * lcfinv, minpoly, p))
+
+
+def _diophantine_univariate(F, m, minpoly, p):
+    r"""
+    Solve univariate Diophantine equations of the form
+
+    .. math ::
+
+        \sum_{f \in F} \left( h_f(x) \cdot \prod_{g \in F \setminus \lbrace f \rbrace } g(x) \right) = x^m
+
+    over `\mathbb Z_p[z]/(\mu(z))`.
+
+    """
+    if len(F) == 2:
+        f, g = F
+        result = _extended_euclidean_algorithm(g, f, minpoly, p)
+        if result is None:
+            return
+        else:
+            s, t, _ = result
+
+        s = s.mul_monom((m, 0))
+        t = t.mul_monom((m, 0))
+
+        q, s = _div(s, f, minpoly, p)
+
+        t += q*g
+
+        s = _trunc(s, minpoly, p)
+        t = _trunc(t, minpoly, p)
+
+        result = [s, t]
+    else:
+        ring = F[0].ring
+        G = [F[-1]]
+
+        for f in reversed(F[1:-1]):
+            G.insert(0, f * G[0])
+
+        S, T = [], [ring.one]
+
+        for f, g in zip(F, G):
+            result = _diophantine([g, f], T[-1], [], 0, minpoly, p)
+            if result is None:
+                return
+            else:
+                t, s = result
+            T.append(t)
+            S.append(s)
+
+        result, S = [], S + [T[-1]]
+
+        for s, f in zip(S, F):
+            r = _div(s.mul_monom((m, 0)), f, minpoly, p)[1]
+            s = _trunc(r, minpoly, p)
+
+            result.append(s)
+
+    return result
+
+
+def _diophantine(F, c, A, d, minpoly, p):
+    r"""
+    Solve multivariate Diophantine equations over `\mathbb Z_p[z]/(\mu(z))`.
+
+    """
+    ring = c.ring
+
+    if not A:
+        S = [ring.zero for _ in F]
+        c = _trunc(c, minpoly, p)
+
+        for (exp,), coeff in c.eject(1).items():
+            T = _diophantine_univariate(F, exp, minpoly, p)
+            if T is None:
+                return
+
+            for j, (s, t) in enumerate(zip(S, T)):
+                S[j] = _trunc(s + t*coeff.set_ring(ring), minpoly, p)
+    else:
+        n = len(A)
+        e = functools.reduce(operator.mul, F)
+
+        a, A = A[-1], A[:-1]
+        B, G = [], []
+
+        for f in F:
+            B.append(e//f)
+            G.append(f.eval(n, a))
+
+        C = c.eval(n, a)
+
+        S = _diophantine(G, C, A, d, minpoly, p)
+        if S is None:
+            return
+        else:
+            S = [s.set_ring(ring) for s in S]
+
+        for s, b in zip(S, B):
+            c = c - s*b
+
+        c = _trunc(c, minpoly, p)
+
+        m = ring.gens[n] - a
+        M = ring.one
+
+        for k in range(d):
+            if not c:
+                break
+
+            M = M * m
+            C = c.diff(x=n, m=k + 1).eval(x=n, a=a)
+
+            if C:
+                C = C.quo_ground(ring.domain.factorial(k + 1))
+                T = _diophantine(G, C, A, d, minpoly, p)
+                if T is None:
+                    return
+
+                for i, t in enumerate(T):
+                    T[i] = t.set_ring(ring) * M
+
+                for i, (s, t) in enumerate(zip(S, T)):
+                    S[i] = s + t
+
+                for t, b in zip(T, B):
+                    c = c - t * b
+
+                c = _trunc(c, minpoly, p)
+
+        S = [_trunc(s, minpoly, p) for s in S]
+
+    return S
+
+
+def _hensel_lift(f, H, LC, A, minpoly, p):
+    r"""
+    Parallel Hensel lifting algorithm over `\mathbb  Z_p[z]/(\mu(z))`.
+
+    Parameters
+    ==========
+
+    f : PolyElement
+        squarefree polynomial in `\mathbb Z[x_0, \ldots, x_n, z]`
+    H : list of PolyElement objects
+        monic univariate factors of `f(x_0, A)` in
+        `\mathbb Z[x_0, z]`
+    LC : list of PolyElement objects
+        true leading coefficients of the irreducible factors of `f`
+    A : list of Integer objects
+        the evaluation point `[a_1, \ldots, a_n]`
+    p : Integer
+        prime number
+
+    Returns
+    =======
+
+    pfactors : list of PolyElement objects
+        irreducible factors of `f` modulo `p`
+
+    """
+    ring = f.ring
+    n = len(A)
+
+    S = [f]
+    H = list(H)
+
+    for i, a in enumerate(reversed(A[1:])):
+        s = S[0].eval(n - i, a)
+        S.insert(0, _trunc(s, minpoly, p))
+
+    d = max(f.degree(_) for _ in ring.gens[1:-1])
+
+    for j, s, a in zip(range(1, n + 1), S, A):
+        G = list(H)
+
+        I, J = A[:j - 1], A[j:]
+
+        Hring = f.ring
+        for _ in range(j, n):
+            Hring = Hring.drop(j + 1)
+
+        x = Hring.gens[0]
+        evalpoints = list(zip(LC[0].ring.gens[j:-1], J))
+
+        for i, (h, lc) in enumerate(zip(H, LC)):
+            if evalpoints:
+                lc = lc.eval(evalpoints)
+            lc = _trunc(lc, minpoly, p).set_ring(Hring)
+            H[i] = h.set_ring(Hring) + (lc - h.eject(*h.ring.gens[1:]).LC.set_ring(Hring))*x**h.degree()
+
+        m = Hring.gens[j] - a
+        M = Hring.one
+
+        c = _trunc(s - functools.reduce(operator.mul, H), minpoly, p)
+
+        dj = s.degree(j)
+
+        for k in range(dj):
+            if not c:
+                break
+
+            M = M * m
+            C = c.diff(x=j, m=k + 1).eval(x=j, a=a)
+
+            if C:
+                C = C.quo_ground(ring.domain.factorial(k + 1))  # coeff of (x_{j-1} - a_{j-1})^(k + 1) in c
+                T = _diophantine(G, C, I, d, minpoly, p)
+                if T is None:
+                    return
+
+                for i, (h, t) in enumerate(zip(H, T)):
+                    H[i] = _trunc(h + t.set_ring(Hring)*M, minpoly, p)
+
+                c = _trunc(s - functools.reduce(operator.mul, H), minpoly, p)
+
+    prod = functools.reduce(operator.mul, H)
+    if _trunc(prod, minpoly, p) != f.trunc_ground(p):
+        return
+    else:
+        return H
+
+
+def _sqf_p(f, minpoly, p):
+    r"""
+    Return ``True`` if `f` is square-free in `\mathbb Z_p[z]/(\mu(z))[x]`.
+
+    """
+    ring = f.ring
+    lcinv, _, gcd = _gf_gcdex(f.eject(*ring.gens[1:]).LC, minpoly, p)
+
+    f = _trunc(f * lcinv.set_ring(ring), minpoly, p)
+
+    if not f:
+        return True
+    else:
+        return _euclidean_algorithm(f, _trunc(f.diff(0), minpoly, p), minpoly, p) == 1
+
+
+def _test_prime(fA, D, minpoly, p, domain):
+    r"""
+    Test if a prime number is suitable for _factor.
+
+    See also
+    ========
+
+    _factor
+
+    """
+    if fA.LC % p == 0 or minpoly.LC % p == 0:
+        return False
+    if not _sqf_p(fA, minpoly, p):
+        return False
+    if D % p == 0:
+        return False
+
+    return True
+
+
+# squarefree f with cont_x0(f) = 1
+def _factor(f, save):
+    r"""
+    Factor a multivariate polynomial `f`, which is squarefree and primitive
+    in `x_0`, in `\mathbb Q(\alpha)[x_0, \ldots, x_n]`.
+
+    References
+    ==========
+
+    * :cite:`Javadi2009factor`
+
+    """
+    ring = f.ring  # Q(alpha)[x_0, ..., x_{n-1}]
+    lcring = ring.drop(0)
+    uniring = ring.drop(*ring.gens[1:])
+    ground = ring.domain.domain
+    n = ring.ngens
+
+    z = Dummy('z')
+    qring = ring.clone(symbols=ring.symbols + (z,), domain=ground)
+    lcqring = qring.drop(0)
+
+    groundring = ground.ring
+    zring = qring.clone(domain=groundring)
+    lczring = zring.drop(0)
+
+    minpoly = _minpoly_from_dense(ring.domain.mod, zring.drop(*zring.gens[:-1]))
+    f_ = _monic_associate(f, zring)
+
+    if save is True:
+        D = minpoly.resultant(minpoly.diff(0))
+    else:
+        D = groundring.one
+
+    # heuristic bound for p-adic lift
+    B = (f_.max_norm() + 1)*D
+
+    lc = f_.eject(*zring.gens[1:]).LC
+    gamma, lcfactors = efactor(_z_to_alpha(lc, lcring))  # over QQ(alpha)[x_1, ..., x_n]
+
+    gamma = ground.convert(gamma)
+    D_ = gamma.denominator
+    gamma_ = gamma.numerator
+    lcfactors_ = []
+
+    for l, exp in lcfactors:
+        den, l_ = _alpha_to_z(l, lcqring).clear_denoms()  # l_ in QQ[x_1, ..., x_n, z], but coeffs in ZZ
+        cont, l_ = l_.set_ring(lczring).primitive()
+        D_ *= den**exp
+        gamma_ *= cont**exp
+        lcfactors_.append((l_, exp))
+
+    f_ = f_.mul_ground(D_)
+    p = 2
+
+    N = 0
+    history = set()
+    tries = 5  # how big should this be?
+
+    while True:
+        for _ in range(tries):
+            A = tuple(random.randint(-N, N) for _ in range(n - 1))
+
+            if A in history:
+                continue
+            else:
+                history.add(A)
+
+            try:
+                result = _test_evaluation_points(f_, gamma_, lcfactors, A, D)
+            except UnluckyLeadingCoefficient:
+                # TODO: check interval
+                C = [random.randint(1, 3*(N + 1)) for _ in range(n - 1)]
+                gens = zring.gens
+                x = gens[0]
+
+                for i, ci in zip(range(1, n + 1), C):
+                    xi = gens[i]
+                    f_ = f_.compose(xi, x + xi.mul_ground(ci))
+
+                lc, factors = _factor(_z_to_alpha(f_, ring), save)
+                gens = factors[0].ring.gens
+                x = gens[0]
+
+                for i, ci in zip(range(1, n + 1), C):
+                    xi = gens[i]
+                    factors = [g.compose(xi, (xi - x).quo_ground(ci)) for g in factors]
+
+                return (lc, factors)
+
+            if result is None:
+                continue
+            else:
+                fA, denoms, divisors = result
+
+            with using(aa_factor_method='trager'):
+                _, fAfactors = _z_to_alpha(fA, uniring).factor_list()
+            if len(fAfactors) == 1:
+                g = _z_to_alpha(f_, ring)
+                return (f.LC, [g.monic()])
+
+            result = _leading_coeffs(f_, fAfactors, gamma_, lcfactors_, A, D, denoms, divisors)
+            if result is None:
+                continue
+            else:
+                f_, lcs, fAfactors_ = result
+
+            prod = groundring.one
+            for lc in lcs:
+                prod *= lc.LC
+            delta = (ground(prod, f_.LC)).numerator
+
+            f_ = f_.mul_ground(delta)
+
+            while not _test_prime(fA, D, minpoly, p, zring.domain):
+                p = nextprime(p)
+
+            pfactors = _hensel_lift(f_, fAfactors_, lcs, A, minpoly, p)
+            if pfactors is None:
+                p = nextprime(p)
+                f_ = f_.primitive()[1]
+                continue
+
+            factors = _padic_lift(f_, pfactors, lcs, B, minpoly, p)
+            if factors is None:
+                p = nextprime(p)
+                f_ = f_.primitive()[1]
+                B *= B
+                continue
+
+            return (f.LC, [_z_to_alpha(g.primitive()[1], ring).monic() for g in factors])
+
+        N += 1
+
+
+# output of the form (lc, [(poly1, exp1), ...])
+def efactor(f, save=True):
+    r"""Factor a multivariate polynomial `f` in `\mathbb Q(\alpha)[x_0, \ldots, x_n]`.
+
+    By default, an estimate of the defect of the algebraic field is included
+    in all computations. If ``save`` is set to ``False``, the defect will be
+    treated as one, thus computations are faster. However, if the defect of
+    `\alpha` is larger than one, this may lead to wrong results.
+
+    References
+    ==========
+
+    * :cite:`Javadi2009factor`
+
+    """
+    ring = f.ring
+
+    assert ring.domain.is_AlgebraicField
+
+    if f.is_ground:
+        return (f.coeff(1), [])
+
+    n = ring.ngens
+
+    if n == 1:
+        with using(aa_factor_method='trager'):
+            return f.factor_list()
+    else:
+        cont, f = f.eject(*ring.gens[1:]).primitive()
+        f = f.inject()
+        if not cont.is_one:
+            lccont, contfactors = efactor(cont)
+            lc, factors = efactor(f)
+            contfactors = [(g.set_ring(ring), exp) for g, exp in contfactors]
+            return (lccont * lc, _sort_factors(contfactors + factors))
+
+        # this is only correct because the content in x_0 is already divided out
+        lc, sqflist = f.sqf_list()
+        factors = []
+        for g, exp in sqflist:
+            lcg, gfactors = _factor(g, save)
+            lc *= lcg
+            factors = factors + [(gi, exp) for gi in gfactors]
+
+        return (lc, _sort_factors(factors))

--- a/diofant/polys/factortools.py
+++ b/diofant/polys/factortools.py
@@ -432,7 +432,12 @@ class _Factor:
                 for h in self._gf_factor_sqf(g):
                     factors.append((h, n))
         elif domain.is_AlgebraicField:
-            coeff, factors = self._aa_factor_trager(f)
+            from .factorization_alg_field import efactor
+
+            _factor_aa_methods = {'trager': self._aa_factor_trager,
+                                  'modular': efactor}
+            method = _factor_aa_methods[query('AA_FACTOR_METHOD')]
+            coeff, factors = method(f)
         else:
             if not domain.is_Exact:
                 domain_inexact, domain = domain, domain.get_exact()

--- a/diofant/polys/polyconfig.py
+++ b/diofant/polys/polyconfig.py
@@ -27,7 +27,7 @@ _default_config = {
     'GF_IRRED_METHOD':            'rabin',
     'GF_FACTOR_METHOD':           'zassenhaus',
 
-    'AA_FACTOR_METHOD':           'trager',
+    'AA_FACTOR_METHOD':           'modular',
 
     'GROEBNER':                   'buchberger',
     'MINPOLY_METHOD':             'compose',

--- a/diofant/polys/polyerrors.py
+++ b/diofant/polys/polyerrors.py
@@ -73,6 +73,10 @@ class ModularGCDFailed(BasePolynomialError):
     """Raised when a modular GCD is failed."""
 
 
+class UnluckyLeadingCoefficient(BasePolynomialError):
+    """Raised when there are unlucky LC."""
+
+
 class HomomorphismFailed(BasePolynomialError):
     """Raised when a homomorphism is failed."""
 

--- a/diofant/polys/solvers.py
+++ b/diofant/polys/solvers.py
@@ -23,8 +23,6 @@ def eqs_to_matrix(eqs, ring):
 
 def solve_lin_sys(eqs, ring):
     """Solve a system of linear equations."""
-    assert ring.domain.is_Field
-
     # transform from equations to matrix form
     matrix = eqs_to_matrix(eqs, ring)
 

--- a/diofant/tests/polys/test_factorization_alg_field.py
+++ b/diofant/tests/polys/test_factorization_alg_field.py
@@ -176,3 +176,13 @@ def test_efactor_wang():
     f = f1*f2*f3*f4
 
     assert efactor(f) == (1, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])
+
+
+@pytest.mark.timeout(60)
+def test_sympyissue_19196():
+    A = QQ.algebraic_field(sqrt(2), root(3, 3))
+    R, x, y, z = ring('x y z', A)
+
+    f1, f2 = x - z/root(3, 3), x**2 + 2*y + sqrt(2)
+    f = f1*f2
+    assert f.factor_list() == (1, [(f1, 1), (f2, 1)])

--- a/diofant/tests/polys/test_factorization_alg_field.py
+++ b/diofant/tests/polys/test_factorization_alg_field.py
@@ -1,0 +1,173 @@
+import random
+
+import pytest
+
+from diofant import I, ring, root, sqrt
+from diofant.domains import QQ, ZZ
+from diofant.polys.factorization_alg_field import (_distinct_prime_divisors,
+                                                   efactor)
+
+
+def test_distinct_prime_divisors():
+    s = [20, 6, 7]
+    assert _distinct_prime_divisors(s, ZZ) == [5, 3, 7]
+
+    s = [15, 18, 11]
+    assert _distinct_prime_divisors(s, ZZ) == [5, 2, 11]
+
+
+def test_efactor_1():
+    R, x, y = ring('x y', QQ.algebraic_field(sqrt(2)))
+
+    f = (x**2 + sqrt(2)*y)
+    assert efactor(f) == (1, [(f, 1)])
+
+    f1 = x + y
+    f2 = x**2 + sqrt(2)*y
+    f = f1 * f2
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1)])
+    assert efactor(f, save=False) == (1, [(f1, 1), (f2, 1)])
+
+    f1 = x + 2**10*y
+    f2 = x**2 + sqrt(2)*y
+    f = f1 * f2
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1)])
+
+    R, x, y, z = ring('x y z', QQ.algebraic_field(sqrt(2)))
+
+    f1 = x - sqrt(2)*z
+    f = f1**2
+
+    assert efactor(f) == (1, [(f1, 2)])
+
+    A3 = QQ.algebraic_field(sqrt(3))
+    R, x, y, z = ring('x y z', A3)
+
+    f1 = z + 1
+    f2 = 3*x*y**2/4 + sqrt(3)
+    f3 = sqrt(3)*y*x**2 + 2*y + z
+    f = f1 * f2**2 * f3
+
+    lc2 = f2.LC
+    lc3 = f3.LC
+
+    assert efactor(f) == (lc2**2*lc3, [(f1, 1), (f2.quo_ground(lc2), 2),
+                                       (f3.quo_ground(lc3), 1)])
+
+    R, x, y = ring('x y', QQ.algebraic_field(I))
+
+    f1 = x - I*y
+    f2 = x + I*y
+    f = f1*f2
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1)])
+
+    f1 = x*(y + 1) + 1
+    f2 = x*(y + I) + 1
+    f3 = x**2*(y - I) + 1
+    f = f1*f2*f3
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1), (f3, 1)])
+
+    lc = R.domain(-2)
+    f1 = x*(y - 3*I) + lc**(-1)
+    f2 = x*(y + 2) + 1
+    f3 = x*(y + I) + 1
+    f = lc*f1*f2*f3
+
+    assert efactor(f) == (lc, [(f1, 1), (f2, 1), (f3, 1)])
+
+    a = sqrt(2)*(1 + I)/2
+    A = QQ.algebraic_field(a)
+    R, x, y = ring('x y', A)
+
+    f1 = x - a**3*y
+    f2 = x - a*y
+    f3 = x + a**3*y
+    f4 = x + a*y
+    f = x**4 + y**4
+
+    assert f1*f2*f3*f4 == f
+    assert efactor(f) == (1, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])
+
+    R, x, y, z = ring('x y z', QQ.algebraic_field(root(2, 5)))
+
+    f1 = y
+    f2 = x - y
+    f3 = x**2 + root(2, 5)*y*z
+    f = f1*f2*f3
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1), (f3, 1)])
+
+    R, x, y, z = ring('x y z', QQ.algebraic_field(sqrt(2), root(3, 3)))
+
+    lc = R.domain.from_expr(root(3, 3))
+    f1 = x - z*root(3, 3)**2/3
+    f2 = x**2 + 2*y + sqrt(2)
+    f = lc*f1*f2
+
+    assert efactor(f) == (lc, [(f1, 1), (f2, 1)])
+
+    a = (-1 + sqrt(5))/4 - I*sqrt((sqrt(5) + 5)/8)
+    A = QQ.algebraic_field(a)
+    a = A.unit
+    R, x, y, z = ring('x y z', A)
+
+    f1 = x**2 + 2*(a**3 + a**2 + a + 1)*x + a*z**2 + a**3*y + 12*a**2
+    f2 = x**2 - 2*a*x - (a**3 + a**2 + a + 1)*z**2 + a**2*y + 12*a**3
+    f = f1*f2
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1)])
+
+    R, x, y = ring('x y', QQ.algebraic_field(root(1, 5, 3)))
+    A = R.domain
+
+    a = A([QQ(17315, 21361), QQ(46350, 21361), QQ(23337, 21361), QQ(-19125, 42722)])
+    b = A([QQ(45917, 85444), QQ(-7870, 21361), QQ(-15120, 21361), QQ(-17355, 85444)])
+    c = A([QQ(104, 521), QQ(650, 521), QQ(130, 521), QQ(5, 521)])
+    d = A([QQ(-29909, 42722), QQ(-20200, 21361), QQ(-6645, 21361), QQ(16196, 21361)])
+
+    e = a*y + b*y**2 + x*c + x*y*d + x**2
+
+    r = efactor(e)
+
+    e1 = (A([QQ(-47, 41), QQ(-25, 41), QQ(-10, 41), QQ(75, 82)])*y + x)
+    e2 = (x + A([QQ(465, 1042), QQ(-175, 521), QQ(-35, 521),
+                 QQ(-163, 1042)])*y + A([QQ(104, 521), QQ(650, 521),
+                                         QQ(130, 521), QQ(5, 521)]))
+
+    assert r == (1, [(e1, 1), (e2, 1)])
+
+
+def test_efactor_random():
+    A3 = QQ.algebraic_field(sqrt(3))
+    R, x, y, z, t = ring('x y z t', A3)
+
+    f1 = x*y - sqrt(3)
+    f2 = z*t + 1
+    f3 = x**2 + 1
+    f4 = x**2 + z*t
+    f = f1*f2*f3*f4
+
+    for seed in [0, 1, 2, 6]:
+        random.seed(seed)
+        assert efactor(f) == (1, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])
+
+
+@pytest.mark.slow
+@pytest.mark.skipif(isinstance(ZZ(42), int), reason='not with gmpy')
+def test_efactor_wang():
+    a = (-1 + sqrt(5))/4 - I*sqrt((sqrt(5) + 5)/8)
+    A = QQ.algebraic_field(a)
+    a = A.unit
+    R, x, y, z = ring('x y z', A)
+
+    f1 = x**2 - 2*a**2*x + a**3*z**2 - (a**3 + a**2 + a + 1)*y + 12*a
+    f2 = x**2 - 2*a**3*x + a**2*z**2 + a*y - 12*(a**3 + a**2 + a + 1)
+    f3 = x**2 + 2*(a**3 + a**2 + a + 1)*x + a*z**2 + a**3*y + 12*a**2
+    f4 = x**2 - 2*a*x - (a**3 + a**2 + a + 1)*z**2 + a**2*y + 12*a**3
+    f = f1*f2*f3*f4
+
+    assert efactor(f) == (1, [(f1, 1), (f2, 1), (f3, 1), (f4, 1)])

--- a/diofant/tests/polys/test_factorization_alg_field.py
+++ b/diofant/tests/polys/test_factorization_alg_field.py
@@ -5,15 +5,21 @@ import pytest
 from diofant import I, ring, root, sqrt
 from diofant.domains import QQ, ZZ
 from diofant.polys.factorization_alg_field import (_distinct_prime_divisors,
-                                                   efactor)
+                                                   _sqf_p, efactor)
 
 
-def test_distinct_prime_divisors():
+def test__distinct_prime_divisors():
     s = [20, 6, 7]
     assert _distinct_prime_divisors(s, ZZ) == [5, 3, 7]
 
     s = [15, 18, 11]
     assert _distinct_prime_divisors(s, ZZ) == [5, 2, 11]
+
+
+def test__sqf_p():
+    R, x, z = ring('x z', ZZ)
+
+    assert _sqf_p(z**2, (z**2 - 2).drop(0), 2) is True
 
 
 def test_efactor_1():

--- a/diofant/tests/polys/test_factorization_alg_field.py
+++ b/diofant/tests/polys/test_factorization_alg_field.py
@@ -3,8 +3,7 @@ import random
 import pytest
 
 from diofant import QQ, ZZ, I, ring, root, sqrt
-from diofant.polys.factorization_alg_field import (_diophantine,
-                                                   _distinct_prime_divisors,
+from diofant.polys.factorization_alg_field import (_distinct_prime_divisors,
                                                    _sqf_p, efactor)
 
 
@@ -20,26 +19,6 @@ def test__sqf_p():
     R, x, z = ring('x z', ZZ)
 
     assert _sqf_p(z**2, (z**2 - 2).drop(0), 2) is True
-
-
-def test__diophantine():
-    R, x, y, z = ring('x y z', ZZ)
-
-    F = [-3 + z, x**2 + 1, x**2 + 3]
-    c = x**3*y
-    minpoly = (z**2 - 3).drop(0).drop(0)
-
-    assert _diophantine(F, c, (5,), 1, minpoly,  2) is None
-
-    F = [-3 + z, x**2 + y]
-
-    assert _diophantine(F, x*y, (2,), 1, minpoly,  2) is None
-
-    F = [-x + z**5, x**2 + y]
-    c = x*y + 1
-    minpoly = (z**2 - 5).drop(0).drop(0)
-
-    assert _diophantine(F, c, (1,), 5, minpoly,  3) == [0, -x*y - 1]
 
 
 def test_efactor_1():

--- a/diofant/tests/polys/test_factorization_alg_field.py
+++ b/diofant/tests/polys/test_factorization_alg_field.py
@@ -2,9 +2,9 @@ import random
 
 import pytest
 
-from diofant import I, ring, root, sqrt
-from diofant.domains import QQ, ZZ
-from diofant.polys.factorization_alg_field import (_distinct_prime_divisors,
+from diofant import QQ, ZZ, I, ring, root, sqrt
+from diofant.polys.factorization_alg_field import (_diophantine,
+                                                   _distinct_prime_divisors,
                                                    _sqf_p, efactor)
 
 
@@ -20,6 +20,26 @@ def test__sqf_p():
     R, x, z = ring('x z', ZZ)
 
     assert _sqf_p(z**2, (z**2 - 2).drop(0), 2) is True
+
+
+def test__diophantine():
+    R, x, y, z = ring('x y z', ZZ)
+
+    F = [-3 + z, x**2 + 1, x**2 + 3]
+    c = x**3*y
+    minpoly = (z**2 - 3).drop(0).drop(0)
+
+    assert _diophantine(F, c, (5,), 1, minpoly,  2) is None
+
+    F = [-3 + z, x**2 + y]
+
+    assert _diophantine(F, x*y, (2,), 1, minpoly,  2) is None
+
+    F = [-x + z**5, x**2 + y]
+    c = x*y + 1
+    minpoly = (z**2 - 5).drop(0).drop(0)
+
+    assert _diophantine(F, c, (1,), 5, minpoly,  3) == [0, -x*y - 1]
 
 
 def test_efactor_1():

--- a/diofant/tests/polys/test_factortools.py
+++ b/diofant/tests/polys/test_factortools.py
@@ -543,10 +543,9 @@ def test_factor_list():
 
     f, r = x**2 + y**2, (1, [(x - I*y, 1), (x + I*y, 1)])
 
-    assert f.factor_list() == r
-
-    with using(aa_factor_method='trager'):
-        assert f.factor_list() == r
+    for method in ('trager', 'modular'):
+        with using(aa_factor_method=method):
+            assert f.factor_list() == r
 
     R, x, y = ring('x y', RR)
 

--- a/diofant/tests/polys/test_factortools.py
+++ b/diofant/tests/polys/test_factortools.py
@@ -401,44 +401,46 @@ def test_dmp_zz_factor():
                                       2*z*t, 1)])
 
 
-def test_dmp_ext_factor():
-    R, x = ring('x', QQ.algebraic_field(I))
+@pytest.mark.parametrize('method', ('modular', 'trager'))
+def test_dmp_ext_factor(method):
+    with using(aa_factor_method=method):
+        R, x = ring('x', QQ.algebraic_field(I))
 
-    assert R(0).factor_list() == (0, [])
-    assert (x + 1).factor_list() == (1, [(x + 1, 1)])
-    assert (2*x + 2).factor_list() == (2, [(x + 1, 1)])
-    assert (7*x**4 + 1).factor_list() == (7, [(x**4 + QQ(1, 7), 1)])
-    assert (x**4 + 1).factor_list() == (1, [(x**2 - I, 1), (x**2 + I, 1)])
-    assert (4*x**2 + 9).factor_list() == (4, [(x - 3*I/2, 1), (x + 3*I/2, 1)])
-    assert (4*x**4 + 8*x**3 + 77*x**2 + 18*x +
-            153).factor_list() == (4, [(x - 3*I/2, 1), (x + 1 + 4*I, 1),
-                                       (x + 1 - 4*I, 1), (x + 3*I/2, 1)])
-    assert (x**2 + 1).factor_list() == (1, [(x - I, 1), (x + I, 1)])
+        assert R(0).factor_list() == (0, [])
+        assert (x + 1).factor_list() == (1, [(x + 1, 1)])
+        assert (2*x + 2).factor_list() == (2, [(x + 1, 1)])
+        assert (7*x**4 + 1).factor_list() == (7, [(x**4 + QQ(1, 7), 1)])
+        assert (x**4 + 1).factor_list() == (1, [(x**2 - I, 1), (x**2 + I, 1)])
+        assert (4*x**2 + 9).factor_list() == (4, [(x - 3*I/2, 1), (x + 3*I/2, 1)])
+        assert (4*x**4 + 8*x**3 + 77*x**2 + 18*x +
+                153).factor_list() == (4, [(x - 3*I/2, 1), (x + 1 + 4*I, 1),
+                                           (x + 1 - 4*I, 1), (x + 3*I/2, 1)])
+        assert (x**2 + 1).factor_list() == (1, [(x - I, 1), (x + I, 1)])
 
-    R, x = ring('x', QQ.algebraic_field(sqrt(2)))
+        R, x = ring('x', QQ.algebraic_field(sqrt(2)))
 
-    assert (x**4 + 1).factor_list() == (1, [(x**2 - sqrt(2)*x + 1, 1),
-                                            (x**2 + sqrt(2)*x + 1, 1)])
+        assert (x**4 + 1).factor_list() == (1, [(x**2 - sqrt(2)*x + 1, 1),
+                                                (x**2 + sqrt(2)*x + 1, 1)])
 
-    f = x**2 + 2*sqrt(2)*x + 2
+        f = x**2 + 2*sqrt(2)*x + 2
 
-    assert f.factor_list() == (1, [(x + sqrt(2), 2)])
-    assert (f**3).factor_list() == (1, [(x + sqrt(2), 6)])
+        assert f.factor_list() == (1, [(x + sqrt(2), 2)])
+        assert (f**3).factor_list() == (1, [(x + sqrt(2), 6)])
 
-    f *= 2
+        f *= 2
 
-    assert f.factor_list() == (2, [(x + sqrt(2), 2)])
-    assert (f**3).factor_list() == (8, [(x + sqrt(2), 6)])
+        assert f.factor_list() == (2, [(x + sqrt(2), 2)])
+        assert (f**3).factor_list() == (8, [(x + sqrt(2), 6)])
 
-    R, x, y = ring('x y', QQ.algebraic_field(sqrt(2)))
+        R, x, y = ring('x y', QQ.algebraic_field(sqrt(2)))
 
-    assert R(0).factor_list() == (0, [])
-    assert (x + 1).factor_list() == (1, [(x + 1, 1)])
-    assert (2*x + 2).factor_list() == (2, [(x + 1, 1)])
-    assert (x**2 - 2*y**2).factor_list() == (1, [(x - sqrt(2)*y, 1),
-                                                 (x + sqrt(2)*y, 1)])
-    assert (2*x**2 - 4*y**2).factor_list() == (2, [(x - sqrt(2)*y, 1),
-                                                   (x + sqrt(2)*y, 1)])
+        assert R(0).factor_list() == (0, [])
+        assert (x + 1).factor_list() == (1, [(x + 1, 1)])
+        assert (2*x + 2).factor_list() == (2, [(x + 1, 1)])
+        assert (x**2 - 2*y**2).factor_list() == (1, [(x - sqrt(2)*y, 1),
+                                                     (x + sqrt(2)*y, 1)])
+        assert (2*x**2 - 4*y**2).factor_list() == (2, [(x - sqrt(2)*y, 1),
+                                                       (x + sqrt(2)*y, 1)])
 
 
 def test_sympyissue_5786():

--- a/docs/internals/polys.rst
+++ b/docs/internals/polys.rst
@@ -295,6 +295,13 @@ Algebraic number fields
 .. currentmodule:: diofant.polys.numberfields
 .. autofunction:: minpoly_groebner
 
+Factorization over algebraic number fields
+==========================================
+
+.. automodule:: diofant.polys.factorization_alg_field
+    :members:
+    :private-members:
+
 Modular GCD
 ===========
 

--- a/docs/internals/polys.rst
+++ b/docs/internals/polys.rst
@@ -307,6 +307,7 @@ Modular GCD
 
 .. automodule:: diofant.polys.modulargcd
     :members:
+    :private-members:
 
 Heuristic GCD
 =============

--- a/docs/modules/domains.rst
+++ b/docs/modules/domains.rst
@@ -41,6 +41,9 @@ Abstract Domains
 Concrete Domains
 ****************
 
+.. autoclass:: FiniteRing
+   :members:
+
 .. autoclass:: FiniteField
    :members:
 

--- a/docs/release/notes-0.12.rst
+++ b/docs/release/notes-0.12.rst
@@ -9,6 +9,7 @@ New features
 
 * Support modular exponentiation of :class:`~diofant.polys.rings.PolyElement`'s, see :pull:`1032`.
 * :func:`~diofant.solvers.inequalities.reduce_inequalities` support solving linear inequalities with Fourier-Motzkin elimination algorithm, see :pull:`1063`.
+* Added :class:`~diofant.domains.FiniteRing` for modular integers, see :pull:`876`.
 
 Major changes
 =============

--- a/docs/release/notes-0.12.rst
+++ b/docs/release/notes-0.12.rst
@@ -73,3 +73,4 @@ These Sympy issues also were addressed:
 * :sympyissue:`20391` Linear programming with simplex method
 * :sympyissue:`19161` When applying simplify on a Poly it fails
 * :sympyissue:`20397` bug in dividing polynomials by module
+* :sympyissue:`19196` Slow f.factor_list

--- a/docs/release/notes-0.12.rst
+++ b/docs/release/notes-0.12.rst
@@ -18,6 +18,7 @@ Major changes
 * Module :mod:`~diofant.polys.factortools` was ported to use sparse polynomial representation, see :pull:`1015`, :pull:`1018`, :pull:`1019`, :pull:`1020` and :pull:`1021`.
 * Module :mod:`~diofant.polys.rootisolation` was ported to use sparse polynomial representation, finally the dense representation is used nowhere, see :pull:`1030`, :pull:`1031` and :pull:`1035`.
 * :func:`~diofant.solvers.inequalities.reduce_inequalities` uses :class:`~diofant.sets.fancysets.ExtendedReals` subsets to solve inequalities, see :pull:`1067`.
+* Added new algorithm for factorization of multivariate polynomials over :class:`~diofant.domains.AlgebraicField`'s (uses Hensel lifting), see :pull:`876`.  Thanks to Katja Sophie Hotz.  Thanks to Kalevi Suominen for help with review.
 
 Compatibility breaks
 ====================


### PR DESCRIPTION
This is a continuation of work in sympy/sympy#2468 and https://github.com/diofant/diofant/pull/712.

Todo:
- [x] ResidueRing -> FiniteRing or QuotientRing?
- [x] full test coverage
- [x] don't use `ring.dmp_LC`
- [x] split out https://github.com/sympy/sympy/commit/b5986e84801a305fafc51827ca40ef010d322925 and https://github.com/sympy/sympy/commit/f52f756b911c529c41c303924542ebf8d0f98f4c?
- [ ] better file/functions names?
- [x] changes for rref/solve_lin_sys?
- [x] rebase & cleanup
- [x] release notes
- [x] up-to-date benchmark
- [x] change this to be a default factorization method for algebraic fields?
- [ ] address TODO
- [ ] check tests

@katjasophie, I assume, I can use your unmerged yet work from sympy/sympy#2468 to the Diofant on terms of the usual SymPy license.  Please reply, if you are disagreed.

Some benchmarks on my system:
```
In [2]: R, x, y = ring('x, y', QQ.algebraic_field(sqrt(2)))
   ...: f = (x + y)*(x**2 + sqrt(2)*y)
   ...: %timeit efactor(f)
   ...: %timeit f.factor_list()
350 ms ± 3.83 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
226 ms ± 875 µs per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [3]: R, x, y, z = ring('x, y, z', QQ.algebraic_field(root(2, 5)))
   ...: f = (x - y)*(x**2*y + root(2, 5)*y**2*z)
   ...: %timeit efactor(f)
   ...: %timeit f.factor_list()
514 ms ± 12.6 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
4.44 s ± 545 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [4]: R, x, y, z = ring('x, y, z', QQ.algebraic_field(sqrt(2), root(3, 3)))
   ...: f = (x**2 + 2*y + sqrt(2))*(root(3, 3)*x - z)
   ...: %timeit efactor(f)
   ...: %timeit f.factor_list()
2.66 s ± 141 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
47.4 s ± 2.39 s per loop (mean ± std. dev. of 7 runs, 1 loop each)
```

New algorithm is clearly better for extensions with high degrees.