### PR TITLE
WIP: latex/pretty: nth root notation for small integers and symbols

### DIFF
--- a/diofant/printing/latex.py
+++ b/diofant/printing/latex.py
@@ -394,7 +394,7 @@ class LatexPrinter(Printer):
         from ..integrals import Integral
 
         # Treat root(x, n) as special case
-        if expr.exp.is_Rational and abs(expr.exp.numerator) == 1 and expr.exp.denominator != 1:
+        if expr.exp.is_Rational and abs(expr.exp.numerator) == 1 and expr.exp.denominator != 1 and abs(expr.exp.denominator) <= 9:
             base = self._print(expr.base)
             expq = expr.exp.denominator
 

--- a/diofant/printing/pretty/pretty.py
+++ b/diofant/printing/pretty/pretty.py
@@ -1330,8 +1330,7 @@ class PrettyPrinter(Printer):
         if power.is_commutative and not e.is_Float:
             if e == -1:
                 return prettyForm("1")/self._print(b)
-            n, d = fraction(e)
-            if n == 1 and d.is_Atom and not e.is_Integer:
+            if e.is_Rational and e.numerator == 1 and abs(e.denominator) <= 9:
                 return self._print_nth_root(b, e)
             if e.is_Rational and e < 0:
                 return prettyForm("1")/self._print(Pow(b, -e, evaluate=False))

--- a/diofant/tests/printing/test_pretty.py
+++ b/diofant/tests/printing/test_pretty.py
@@ -1773,19 +1773,28 @@ def test_pretty_sqrt():
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = root(2, 1000)
+    expr = root(2, 999)
     ascii_str = \
         """\
-1000___\n\
-  \\/ 2 \
+999___\n\
+ \\/ 2 \
 """
     ucode_str = \
         """\
-1000___\n\
-  ╲╱ 2 \
+999___\n\
+ ╲╱ 2 \
 """
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
+
+    expr = root(2, 1000)
+    ascii_str = \
+        """\
+ 1/1000\n\
+2      \
+"""
+    assert pretty(expr) == ascii_str
+    assert upretty(expr) == ascii_str
 
     expr = sqrt(x**2 + 1)
     ascii_str = \
@@ -1847,11 +1856,11 @@ x ___\n\
     assert pretty(expr) == ascii_str
     assert upretty(expr) == ucode_str
 
-    expr = root(2 + (1 + x**2)/(2 + x), 4) + (1 + root(x, 1000))/sqrt(3 + x**2)
+    expr = root(2 + (1 + x**2)/(2 + x), 4) + (1 + root(x, 100))/sqrt(3 + x**2)
     ascii_str = \
         """\
      ____________              \n\
-    /      2        1000___    \n\
+    /      2         100___    \n\
    /      x  + 1      \\/ x  + 1\n\
 4 /   2 + ------  + -----------\n\
 \\/        x + 2        ________\n\
@@ -1861,7 +1870,7 @@ x ___\n\
     ucode_str = \
         """\
      ____________              \n\
-    ╱      2        1000___    \n\
+    ╱      2         100___    \n\
    ╱      x  + 1      ╲╱ x  + 1\n\
 4 ╱   2 + ──────  + ───────────\n\
 ╲╱        x + 2        ________\n\
@@ -5305,3 +5314,43 @@ def test_pretty_Mod():
     assert upretty(Mod(x, 7) + 1) == ucode_str4
     assert pretty(2 * Mod(x, 7)) == ascii_str5
     assert upretty(2 * Mod(x, 7)) == ucode_str5
+
+
+def test_Pow_Eth_root_pith_root():
+    assert pretty(pi**(exp(-1))) == \
+        'E ____\n'\
+        '\\/ pi '
+
+    assert upretty(pi**(exp(-1))) == \
+        'ℯ ___\n'\
+        '╲╱ π '
+
+    assert pretty(pi**(1/pi)) == \
+        'pi____\n'\
+        '\\/ pi '
+
+    assert upretty(pi**(1/pi)) == \
+        'π ___\n'\
+        '╲╱ π '
+
+
+def test_Pow_symbol_short_and_long():
+    assert upretty(pi**(1/EulerGamma)) == \
+        'γ ___\n'\
+        '╲╱ π '
+    assert pretty(pi**(1/EulerGamma)) == \
+        '      1     \n'\
+        '  ----------\n'\
+        '  EulerGamma\n'\
+        'pi          '
+
+    z = Symbol("x_17")
+    assert upretty(7**(1/z)) == \
+        'x₁₇___\n'\
+        ' ╲╱ 7 '
+
+    assert pretty(7**(1/z)) == \
+        '  1  \n'\
+        ' ----\n'\
+        ' x_17\n'\
+        '7    '


### PR DESCRIPTION
TODO

  - [x] pretty
  - [ ] latex
  - [x] tests
  - [x] adjust older tests
  - [x] refactor `_print_nth_root`.
  - [ ] decide on using this notation for symbols (not just integers)
  - [ ] decide on magic threshold: currently three digits
  - [ ] regression tests for closed issues