### PR TITLE
Fix broken version in dist.zip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       TERM: xterm
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:


### PR DESCRIPTION
Since ~20 Feb we have broken version's in the Github Actions artifacts (dist.zip).  This should be fixed before release.