### PR TITLE
calculus: fix handling nested Order() terms in Limit.doit()

### DIFF
--- a/diofant/core/function.py
+++ b/diofant/core/function.py
@@ -493,7 +493,7 @@ class Function(Application, Expr):
         and possible:
 
         >>> loggamma(1/x)._eval_nseries(x, 0, None)
-        -1/x - log(x)/x + log(x)/2 + O(1, x)
+        -log(x)/x + O(1/x)
 
         """
         from ..calculus import Order

--- a/diofant/core/power.py
+++ b/diofant/core/power.py
@@ -1172,7 +1172,7 @@ class Pow(Expr):
             if c.is_negative:
                 if t.is_Order:
                     return self._eval_nseries(x, n + 1, logx)
-                l = floor(arg(t.removeO()*c)/(2*pi)).limit(x, 0)
+                l = floor(arg(t*c)/2/pi).limit(x, 0)
                 if l.is_finite:
                     factor *= exp(2*pi*I*self.exp*l)
                 else:

--- a/diofant/functions/elementary/exponential.py
+++ b/diofant/functions/elementary/exponential.py
@@ -356,35 +356,34 @@ class log(Function):
 
     def _eval_nseries(self, x, n, logx):
         from ...calculus import Order
-        from .complexes import arg
+        from .complexes import arg as argument
         from .integers import floor
         if not logx:
             logx = log(x)
-        arg_series = self.args[0].nseries(x, n=n, logx=logx)
+        arg = self.args[0]
+        arg_series = arg.nseries(x, n=n, logx=logx)
         while arg_series.is_Order:
             n += 1
-            arg_series = self.args[0].nseries(x, n=n, logx=logx)
+            arg_series = arg.nseries(x, n=n, logx=logx)
         arg0 = arg_series.as_leading_term(x)
         c, e = arg0.as_coeff_exponent(x)
-        t = (arg_series/arg0 - 1).cancel().nseries(x, n=n, logx=logx)
+        res = term = t = ((arg_series - arg0)/arg0).nseries(x, n=n, logx=logx)
         # series of log(1 + t) in t
-        log_series = term = t
         for i in range(1, n):
             term *= -i*t/(i + 1)
-            term = term.nseries(x, n=n, logx=logx)
-            log_series += term
-        if t != 0:
-            log_series += Order(t**n, x)
-            # branch handling
-            if c.is_negative:
-                if t.is_Order:
-                    return self._eval_nseries(x, n + 1, logx)
-                l = floor(arg(t*c)/2/pi).limit(x, 0)
-                if l.is_finite:
-                    log_series += 2*I*pi*l
-                else:
-                    raise NotImplementedError
-        return log_series + log(c) + e*logx
+            term = term.series(x, n=n, logx=logx)
+            res += term
+        res += Order(t**n, x)
+        # branch handling
+        if c.is_negative:
+            if t.is_Order:
+                return self._eval_nseries(x, n + 1, logx)
+            l = 2*pi*I*floor(argument(t*c)/2/pi).limit(x, 0)
+            if l.is_finite:
+                res += l
+            else:
+                raise NotImplementedError
+        return res + log(c) + e*logx
 
     def _eval_as_leading_term(self, x):
         arg = self.args[0].as_leading_term(x)

--- a/diofant/functions/elementary/exponential.py
+++ b/diofant/functions/elementary/exponential.py
@@ -379,7 +379,7 @@ class log(Function):
             if c.is_negative:
                 if t.is_Order:
                     return self._eval_nseries(x, n + 1, logx)
-                l = floor(arg(t.removeO()*c)/(2*pi)).limit(x, 0)
+                l = floor(arg(t*c)/2/pi).limit(x, 0)
                 if l.is_finite:
                     log_series += 2*I*pi*l
                 else:

--- a/diofant/tests/calculus/test_limits.py
+++ b/diofant/tests/calculus/test_limits.py
@@ -34,6 +34,8 @@ def test_basic1():
     limit(Sum(1/x, (x, 1, y)) - 1/y, y, oo)
     assert limit(nan, x, -oo) == nan
     assert limit(O(2, x)*x, x, nan) == nan
+    assert limit(O(x), x, 0) == 0
+    assert limit(O(1, x), x, 0) != 1
     assert limit(sin(O(x)), x, 0) == 0
     assert limit(1/(x - 1), x, 1) == oo
     assert limit(1/(x - 1), x, 1, dir=1) == -oo

--- a/diofant/tests/core/test_function.py
+++ b/diofant/tests/core/test_function.py
@@ -409,8 +409,7 @@ def test_function__eval_nseries():
         sqrt(2)*x**Rational(3, 2)/12 + O(x**2)
     assert acos(1 + x)._eval_nseries(x, 4, None) == sqrt(2)*I*sqrt(x) - \
         sqrt(2)*I*x**(3/2)/12 + O(x**2)
-    assert loggamma(1/x)._eval_nseries(x, 0, None) == \
-        log(x)/2 - log(x)/x - 1/x + O(1, x)
+    assert loggamma(1/x)._eval_nseries(x, 0, None) == O(1/x) - log(x)/x
     assert loggamma(log(1/x)).series(x, n=1, logx=y) == loggamma(-y)
 
     # issue sympy/sympy#6725:

--- a/diofant/tests/functions/test_gamma_functions.py
+++ b/diofant/tests/functions/test_gamma_functions.py
@@ -400,12 +400,12 @@ def test_loggamma():
 
     def tN(N, M):
         assert loggamma(1/x)._eval_nseries(x, n=N).getn() == M
-    tN(0, 0)
-    tN(1, 1)
-    tN(2, 3)
-    tN(3, 3)
-    tN(4, 5)
-    tN(5, 5)
+    tN(0, -1)
+    tN(1, +1)
+    tN(2, +3)
+    tN(3, +3)
+    tN(4, +5)
+    tN(5, +5)
 
 
 def test_polygamma_expansion():


### PR DESCRIPTION
- [ ] adapt gruntz.py instead?
- [x] restrict to Add arguments?