### PR TITLE
Remove pip and wheel build dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,5 @@
 [build-system]
-requires = ['pip>=20.3', 'setuptools>=61', 'wheel',
-            'setuptools_scm[toml]>=6.0']
+requires = ['setuptools>=61', 'setuptools_scm[toml]>=6.0']
 build-backend = 'setuptools.build_meta'
 
 [project]


### PR DESCRIPTION
1. I don't think pip is needed by setuptools to build anything.
2. setuptools uses a [PEP 517](https://peps.python.org/pep-0517/#get-requires-for-build-wheel) hook to add wheel automatically only when building a wheel (and not an sdist), so declaring our own dependency on wheel is unnecessary.